### PR TITLE
✨ [FEAT] store-service에 querydsl 추가

### DIFF
--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 ext {
     set('springCloudVersion', "2025.0.0")
+    set('querydslVersion', "5.0.0")  // Querydsl 버전 명시적 정의
 }
 
 dependencies {
@@ -44,6 +45,12 @@ dependencies {
 
     // Springdoc OpenAPI (Swagger)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // Querydsl 추가 - 버전을 명시적으로 지정
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {
@@ -52,3 +59,24 @@ dependencyManagement {
     }
 }
 tasks.register("prepareKotlinBuildScriptModel"){}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+clean {
+    delete file(querydslDir)
+}
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+tasks.register("compileQuerydsl", JavaCompile) {
+    source = sourceSets.main.java
+    classpath = configurations.annotationProcessor + sourceSets.main.compileClasspath
+    destinationDirectory = file(querydslDir)
+    options.annotationProcessorPath = configurations.annotationProcessor
+}

--- a/store-service/build.gradle
+++ b/store-service/build.gradle
@@ -25,6 +25,14 @@ repositories {
 
 ext {
     set('springCloudVersion', "2025.0.0")
+    set('querydslVersion', "5.0.0")  // Querydsl 버전 명시적 정의
+}
+
+// dependencyManagement를 dependencies보다 먼저 선언
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 dependencies {
@@ -41,16 +49,36 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Springdoc OpenAPI (Swagger)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-}
 
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-    }
+    // Querydsl 추가 - 버전을 명시적으로 지정
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+clean {
+    delete file(querydslDir)
+}
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+tasks.register("compileQuerydsl", JavaCompile) {
+    source = sourceSets.main.java
+    classpath = configurations.annotationProcessor + sourceSets.main.compileClasspath
+    destinationDirectory = file(querydslDir)
+    options.annotationProcessorPath = configurations.annotationProcessor
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/config/QueryDslConfig.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.cloudfour.storeservice.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/MenuCategoryRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/MenuCategoryRepository.java
@@ -1,15 +1,10 @@
 package com.example.cloudfour.storeservice.domain.menu.repository;
 
 import com.example.cloudfour.storeservice.domain.menu.entity.MenuCategory;
+import com.example.cloudfour.storeservice.domain.menu.repository.querydsl.MenuCategoryQueryDslRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 import java.util.UUID;
 
-public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID> {
+public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID>, MenuCategoryQueryDslRepository {
 
-    @Query("SELECT mc FROM MenuCategory mc WHERE mc.category = :category")
-    Optional<MenuCategory> findByCategory(@Param("category") String category);
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/MenuOptionRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/MenuOptionRepository.java
@@ -1,19 +1,11 @@
 package com.example.cloudfour.storeservice.domain.menu.repository;
 
 import com.example.cloudfour.storeservice.domain.menu.entity.MenuOption;
+import com.example.cloudfour.storeservice.domain.menu.repository.querydsl.MenuOptionQueryDslRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.UUID;
 
-public interface MenuOptionRepository extends JpaRepository<MenuOption, UUID> {
+public interface MenuOptionRepository extends JpaRepository<MenuOption, UUID> , MenuOptionQueryDslRepository {
 
-    List<MenuOption> findByMenuIdOrderByAdditionalPrice(UUID menuId);
-
-    boolean existsByMenuIdAndOptionName(UUID menuId, String optionName);
-
-    @Query("SELECT mo FROM MenuOption mo JOIN FETCH mo.menu WHERE mo.id = :optionId")
-    java.util.Optional<MenuOption> findByIdWithMenu(@Param("optionId") UUID optionId);
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/MenuRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/MenuRepository.java
@@ -1,53 +1,10 @@
 package com.example.cloudfour.storeservice.domain.menu.repository;
 
 import com.example.cloudfour.storeservice.domain.menu.entity.Menu;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
+import com.example.cloudfour.storeservice.domain.menu.repository.querydsl.MenuQueryDslRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
-public interface MenuRepository extends JpaRepository<Menu, UUID> {
-    @Query("SELECT m FROM Menu m WHERE m.store.id = :storeId AND m.store.isDeleted = false AND m.store.userIsDeleted = false ORDER BY m.createdAt DESC")
-    List<Menu> findByStoreIdAndDeletedFalseOrderByCreatedAtDesc(@Param("storeId") UUID storeId);
+public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuQueryDslRepository {
 
-    @Query("SELECT m FROM Menu m WHERE m.store.id = :storeId AND m.store.isDeleted = false AND m.store.userIsDeleted = false AND m.createdAt < :cursor ORDER BY m.createdAt DESC")
-    Slice<Menu> findByStoreIdAndDeletedFalseAndCreatedAtBefore(@Param("storeId") UUID storeId, @Param("cursor") LocalDateTime cursor, Pageable pageable);
-
-    @Query("SELECT m FROM Menu m WHERE m.store.id = :storeId AND m.store.isDeleted = false AND m.store.userIsDeleted = false AND m.menuCategory.id =:menuCategoryId AND m.createdAt < :cursor ORDER BY m.createdAt DESC")
-    Slice<Menu> findByStoreIdAndMenuCategoryIdAndDeletedFalseAndCreatedAtBefore(@Param("storeId") UUID storeId, @Param("menuCategoryId") UUID menuCategoryId ,@Param("cursor") LocalDateTime cursor, Pageable pageable);
-
-    @Query("SELECT COUNT(m) > 0 FROM Menu m WHERE m.name = :name AND m.store.id = :storeId AND m.store.isDeleted = false AND m.store.userIsDeleted = false")
-    boolean existsByNameAndStoreId(@Param("name") String name, @Param("storeId") UUID storeId);
-
-//    @Query("SELECT m FROM Menu m " +
-//            "LEFT JOIN OrderItem oi ON m.id = oi.menu.id " +
-//            "WHERE m.store.isDeleted = false AND m.store.userIsDeleted = false " +
-//            "GROUP BY m.id " +
-//            "ORDER BY COUNT(oi.id) DESC, m.createdAt DESC")
-//    List<Menu> findTopMenusByOrderCount(Pageable pageable);
-//
-//    @Query("SELECT m FROM Menu m " +
-//            "LEFT JOIN OrderItem oi ON m.id = oi.menu.id " +
-//            "LEFT JOIN oi.order o " +
-//            "WHERE m.store.isDeleted = false AND m.store.userIsDeleted = false " +
-//            "AND o.createdAt BETWEEN :startTime AND :endTime " +
-//            "GROUP BY m.id " +
-//            "ORDER BY COUNT(oi.id) DESC, m.createdAt DESC")
-//    List<Menu> findTopMenusByTimeRange(@Param("startTime") LocalDateTime startTime,
-//                                       @Param("endTime") LocalDateTime endTime,
-//                                       Pageable pageable);
-//
-//    @Query("SELECT m FROM Menu m " +
-//            "LEFT JOIN OrderItem oi ON m.id = oi.menu.id " +
-//            "WHERE m.store.isDeleted = false AND m.store.userIsDeleted = false " +
-//            "AND m.store.region.siDo = :si " +
-//            "AND m.store.region.siGunGu = :gu " +
-//            "GROUP BY m.id " +
-//            "ORDER BY COUNT(oi.id) DESC, m.createdAt DESC")
-//    List<Menu> findTopMenusByRegion(@Param("si") String si, @Param("gu") String gu, Pageable pageable);
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuCategoryQueryDslRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuCategoryQueryDslRepository.java
@@ -1,0 +1,9 @@
+package com.example.cloudfour.storeservice.domain.menu.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.menu.entity.MenuCategory;
+
+import java.util.Optional;
+
+public interface MenuCategoryQueryDslRepository {
+    Optional<MenuCategory> findByCategory(String category);
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuCategoryQueryDslRepositoryImpl.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuCategoryQueryDslRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.storeservice.domain.menu.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.menu.entity.MenuCategory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.example.cloudfour.storeservice.domain.menu.entity.QMenuCategory.menuCategory;
+
+@Repository
+@RequiredArgsConstructor
+public class MenuCategoryQueryDslRepositoryImpl implements MenuCategoryQueryDslRepository{
+    private final JPAQueryFactory query;
+
+
+    @Override
+    public Optional<MenuCategory> findByCategory(String category) {
+        return Optional.ofNullable(query.selectFrom(menuCategory).where(menuCategory.category.eq(category)).fetchOne());
+    }
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuOptionQueryDslRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuOptionQueryDslRepository.java
@@ -1,0 +1,15 @@
+package com.example.cloudfour.storeservice.domain.menu.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.menu.entity.MenuOption;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MenuOptionQueryDslRepository {
+    List<MenuOption> findByMenuIdOrderByAdditionalPrice(UUID menuId);
+
+    Optional<MenuOption> findByIdWithMenu(UUID optionId);
+
+    boolean existsByMenuIdAndOptionName(UUID menuId, String optionName);
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuOptionQueryDslRepositoryImpl.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuOptionQueryDslRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.example.cloudfour.storeservice.domain.menu.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.menu.entity.MenuOption;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.example.cloudfour.storeservice.domain.menu.entity.QMenu.menu;
+import static com.example.cloudfour.storeservice.domain.menu.entity.QMenuOption.menuOption;
+
+@Repository
+@RequiredArgsConstructor
+public class MenuOptionQueryDslRepositoryImpl implements MenuOptionQueryDslRepository{
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<MenuOption> findByMenuIdOrderByAdditionalPrice(UUID menuId) {
+        return query.selectFrom(menuOption).leftJoin(menuOption.menu, menu).fetchJoin()
+                .where(menu.id.eq(menuId)).fetch();
+    }
+
+    @Override
+    public Optional<MenuOption> findByIdWithMenu(UUID optionId) {
+        return Optional.ofNullable(query.selectFrom(menuOption).join(menuOption.menu,menu).fetchJoin()
+                .where(menuOption.id.eq((optionId))).fetchOne());
+    }
+
+    @Override
+    public boolean existsByMenuIdAndOptionName(UUID menuId, String optionName) {
+        return query.selectFrom(menuOption).join(menuOption.menu,menu).fetchJoin()
+                .where(menu.id.eq(menuId), menuOption.optionName.eq(optionName)).fetchFirst() != null;
+    }
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuQueryDslRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuQueryDslRepository.java
@@ -1,0 +1,19 @@
+package com.example.cloudfour.storeservice.domain.menu.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.menu.entity.Menu;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface MenuQueryDslRepository {
+    List<Menu> findByStoreIdAndDeletedFalseOrderByCreatedAtDesc(UUID storeId);
+
+    Slice<Menu> findByStoreIdAndDeletedFalseAndCreatedAtBefore(UUID storeId, LocalDateTime cursor, Pageable pageable);
+
+    Slice<Menu> findByStoreIdAndMenuCategoryIdAndDeletedFalseAndCreatedAtBefore(UUID storeId, UUID menuCategoryId ,LocalDateTime cursor, Pageable pageable);
+
+    boolean existsByNameAndStoreId(String name, UUID storeId);
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuQueryDslRepositoryImpl.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/menu/repository/querydsl/MenuQueryDslRepositoryImpl.java
@@ -1,0 +1,93 @@
+package com.example.cloudfour.storeservice.domain.menu.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.menu.entity.Menu;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static com.example.cloudfour.storeservice.domain.menu.entity.QMenu.menu;
+import static com.example.cloudfour.storeservice.domain.menu.entity.QMenuCategory.menuCategory;
+import static com.example.cloudfour.storeservice.domain.store.entity.QStore.store;
+
+@Repository
+@RequiredArgsConstructor
+public class MenuQueryDslRepositoryImpl implements MenuQueryDslRepository{
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<Menu> findByStoreIdAndDeletedFalseOrderByCreatedAtDesc(UUID storeId) {
+        return query.selectFrom(menu).join(menu.store, store).fetchJoin()
+                .where(store.id.eq(storeId), store.isDeleted.eq(false))
+                .orderBy(menu.createdAt.desc()).fetch();
+    }
+
+    @Override
+    public Slice<Menu> findByStoreIdAndDeletedFalseAndCreatedAtBefore(UUID storeId, LocalDateTime cursor, Pageable pageable) {
+        int pageSize = pageable.getPageSize();
+
+        List<Menu> menus = query.selectFrom(menu).join(menu.store,store).fetchJoin()
+                .where(store.id.eq(storeId), store.isDeleted.eq(false)
+                ,store.createdAt.lt(cursor)).orderBy(store.createdAt.desc()).limit(pageSize+1).fetch();
+
+        boolean hasNext = menus.size() > pageSize;
+        if(hasNext){
+            menus.remove(pageSize);
+        }
+        return new SliceImpl<>(menus,pageable,hasNext);
+    }
+
+    @Override
+    public Slice<Menu> findByStoreIdAndMenuCategoryIdAndDeletedFalseAndCreatedAtBefore(UUID storeId, UUID menuCategoryId, LocalDateTime cursor, Pageable pageable) {
+        int pageSize = pageable.getPageSize();
+
+        List<Menu> menus = query.selectFrom(menu).join(menu.store,store).join(menu.menuCategory,menuCategory).fetchJoin()
+                .where(store.id.eq(storeId), store.isDeleted.eq(false), menuCategory.id.eq(menuCategoryId)
+                        ,store.createdAt.lt(cursor)).orderBy(store.createdAt.desc()).limit(pageSize+1).fetch();
+
+        boolean hasNext = menus.size() > pageSize;
+        if(hasNext){
+            menus.remove(pageSize);
+        }
+        return new SliceImpl<>(menus,pageable,hasNext);
+    }
+
+    @Override
+    public boolean existsByNameAndStoreId(String name, UUID storeId) {
+        return query.selectFrom(menu).join(menu.store, store).fetchJoin()
+                .where(menu.name.eq(name), store.id.eq(storeId)).fetchFirst() != null;
+    }
+}
+//    @Query("SELECT m FROM Menu m " +
+//            "LEFT JOIN OrderItem oi ON m.id = oi.menu.id " +
+//            "WHERE m.store.isDeleted = false AND m.store.userIsDeleted = false " +
+//            "GROUP BY m.id " +
+//            "ORDER BY COUNT(oi.id) DESC, m.createdAt DESC")
+//    List<Menu> findTopMenusByOrderCount(Pageable pageable);
+
+
+//    @Query("SELECT m FROM Menu m " +
+//            "LEFT JOIN OrderItem oi ON m.id = oi.menu.id " +
+//            "LEFT JOIN oi.order o " +
+//            "WHERE m.store.isDeleted = false AND m.store.userIsDeleted = false " +
+//            "AND o.createdAt BETWEEN :startTime AND :endTime " +
+//            "GROUP BY m.id " +
+//            "ORDER BY COUNT(oi.id) DESC, m.createdAt DESC")
+//    List<Menu> findTopMenusByTimeRange(@Param("startTime") LocalDateTime startTime,
+//                                       @Param("endTime") LocalDateTime endTime,
+//                                       Pageable pageable);
+//
+//    @Query("SELECT m FROM Menu m " +
+//            "LEFT JOIN OrderItem oi ON m.id = oi.menu.id " +
+//            "WHERE m.store.isDeleted = false AND m.store.userIsDeleted = false " +
+//            "AND m.store.region.siDo = :si " +
+//            "AND m.store.region.siGunGu = :gu " +
+//            "GROUP BY m.id " +
+//            "ORDER BY COUNT(oi.id) DESC, m.createdAt DESC")
+//    List<Menu> findTopMenusByRegion(@Param("si") String si, @Param("gu") String gu, Pageable pageable);

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/region/repository/RegionQueryDslRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/region/repository/RegionQueryDslRepository.java
@@ -1,0 +1,9 @@
+package com.example.cloudfour.storeservice.domain.region.repository;
+
+import com.example.cloudfour.storeservice.domain.region.entity.Region;
+
+import java.util.Optional;
+
+public interface RegionQueryDslRepository {
+    Optional<Region> findBySiDoAndSiGunGuAndEupMyeonDong(String siDo, String siGunGu, String eupMyeonDong);
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/region/repository/RegionQueryDslRepositoryImpl.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/region/repository/RegionQueryDslRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.example.cloudfour.storeservice.domain.region.repository;
+
+import com.example.cloudfour.storeservice.domain.region.entity.Region;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.example.cloudfour.storeservice.domain.region.entity.QRegion.region;
+
+@Repository
+@RequiredArgsConstructor
+public class RegionQueryDslRepositoryImpl implements RegionQueryDslRepository {
+    private final JPAQueryFactory query;
+
+    @Override
+    public Optional<Region> findBySiDoAndSiGunGuAndEupMyeonDong(String siDo, String siGunGu, String eupMyeonDong) {
+        BooleanBuilder regionBuilder = new BooleanBuilder();
+        if (eupMyeonDong != null) regionBuilder.or(region.eupMyeonDong.eq(eupMyeonDong));
+        if (siGunGu != null) regionBuilder.or(region.siGunGu.eq(siGunGu));
+        if (siDo != null) regionBuilder.or(region.siDo.eq(siDo));
+
+        return Optional.ofNullable(query.selectFrom(region).where(regionBuilder).fetchFirst());
+    }
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/region/repository/RegionRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/region/repository/RegionRepository.java
@@ -3,9 +3,8 @@ package com.example.cloudfour.storeservice.domain.region.repository;
 import com.example.cloudfour.storeservice.domain.region.entity.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
 import java.util.UUID;
 
-public interface RegionRepository extends JpaRepository<Region, UUID> {
-    Optional<Region> findBySiDoAndSiGunGuAndEupMyeonDong(String siDo, String siGunGu, String eupMyeonDong);
+public interface RegionRepository extends JpaRepository<Region, UUID> , RegionQueryDslRepository{
+
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/StoreCategoryRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/StoreCategoryRepository.java
@@ -1,12 +1,11 @@
 package com.example.cloudfour.storeservice.domain.store.repository;
 
 import com.example.cloudfour.storeservice.domain.store.entity.StoreCategory;
+import com.example.cloudfour.storeservice.domain.store.repository.querydsl.StoreCategoryQueryDslRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
 import java.util.UUID;
 
-public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
+public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID>, StoreCategoryQueryDslRepository {
 
-    Optional<StoreCategory> findByCategory(String category);
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/StoreRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/StoreRepository.java
@@ -1,30 +1,12 @@
 package com.example.cloudfour.storeservice.domain.store.repository;
 
 import com.example.cloudfour.storeservice.domain.store.entity.Store;
-import org.springframework.data.domain.Slice;
+import com.example.cloudfour.storeservice.domain.store.repository.querydsl.StoreQueryDslRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
-import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public interface StoreRepository extends JpaRepository<Store, UUID> {
-    boolean existsByName(String name);
-
-    Optional<Store> findByIdAndIsDeletedFalse(UUID storeId);
-
-    @Query("SELECT s FROM Store s WHERE s.isDeleted = false AND s.storeCategory.id = :categoryId AND s.createdAt < :cursor ORDER BY s.createdAt DESC")
-    Slice<Store> findAllByCategoryAndCursor(@Param("categoryId") UUID categoryId, @Param("cursor") LocalDateTime cursor, Pageable pageable);
-
-    @Query("select s from Store s where s.isDeleted = false " +
-            "and (s.name ilike concat('%', :keyword, '%')" +
-            "or s.storeCategory.category ilike concat('%', :keyword, '%'))" +
-            "and s.createdAt < :cursor ORDER BY s.createdAt DESC")
-    Slice<Store> findAllByKeyWord(@Param("keyword") String keyword, LocalDateTime cursor, Pageable pageable);
-
+public interface StoreRepository extends JpaRepository<Store, UUID>, StoreQueryDslRepository {
     void deleteAllByCreatedAtBefore(LocalDateTime createdAtBefore);
 }

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/querydsl/StoreCategoryQueryDslRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/querydsl/StoreCategoryQueryDslRepository.java
@@ -1,0 +1,9 @@
+package com.example.cloudfour.storeservice.domain.store.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.store.entity.StoreCategory;
+
+import java.util.Optional;
+
+public interface StoreCategoryQueryDslRepository {
+    Optional<StoreCategory> findByCategory(String category);
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/querydsl/StoreCategoryQueryDslRepositoryImpl.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/querydsl/StoreCategoryQueryDslRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.storeservice.domain.store.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.store.entity.StoreCategory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.example.cloudfour.storeservice.domain.store.entity.QStoreCategory.storeCategory;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreCategoryQueryDslRepositoryImpl implements StoreCategoryQueryDslRepository{
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public Optional<StoreCategory> findByCategory(String category) {
+        return Optional.ofNullable(query.selectFrom(storeCategory).where(storeCategory.category.eq(category)).fetchOne());
+    }
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/querydsl/StoreQueryDslRepository.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/querydsl/StoreQueryDslRepository.java
@@ -1,0 +1,20 @@
+package com.example.cloudfour.storeservice.domain.store.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.store.entity.Store;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface StoreQueryDslRepository {
+    Optional<Store> findByIdAndIsDeletedFalse(UUID storeId);
+
+    Slice<Store> findAllByCategoryAndCursor(UUID categoryId, LocalDateTime cursor, Pageable pageable);
+
+    Slice<Store> findAllByKeyWordAndRegion(String keyword, LocalDateTime cursor, Pageable pageable
+            ,String siDo, String siGunGu, String eupMyeongDong);
+
+    boolean existsByName(String name);
+}

--- a/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/querydsl/StoreQueryDslRepositoryImpl.java
+++ b/store-service/src/main/java/com/example/cloudfour/storeservice/domain/store/repository/querydsl/StoreQueryDslRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.example.cloudfour.storeservice.domain.store.repository.querydsl;
+
+import com.example.cloudfour.storeservice.domain.store.entity.Store;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.example.cloudfour.storeservice.domain.region.entity.QRegion.region;
+import static com.example.cloudfour.storeservice.domain.store.entity.QStore.store;
+import static com.example.cloudfour.storeservice.domain.store.entity.QStoreCategory.storeCategory;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreQueryDslRepositoryImpl implements StoreQueryDslRepository{
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public Optional<Store> findByIdAndIsDeletedFalse(UUID storeId) {
+        return Optional.ofNullable(query.selectFrom(store)
+                .where(store.id.eq(storeId), store.isDeleted.eq(false), store.userIsDeleted.eq(false))
+                .fetchOne());
+    }
+
+    @Override
+    public Slice<Store> findAllByCategoryAndCursor(UUID categoryId, LocalDateTime cursor, Pageable pageable) {
+        int pageSize = pageable.getPageSize();
+        List<Store> stores = query.selectFrom(store)
+                .where(store.isDeleted.eq(false), store.storeCategory.id.eq(categoryId)
+                        , store.createdAt.lt(cursor)).orderBy(store.createdAt.desc()).limit(pageSize+1)
+                .fetch();
+
+        boolean hasNext = stores.size() > pageSize;
+        if(hasNext){
+            stores.remove(pageSize);
+        }
+        return new SliceImpl<>(stores,pageable,hasNext);
+    }
+
+    @Override
+    public Slice<Store> findAllByKeyWordAndRegion(String keyword, LocalDateTime cursor, Pageable pageable
+    ,String siDo, String siGunGu, String eupMyeongDong) {
+        int pageSize = pageable.getPageSize();
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(store.isDeleted.eq(false));
+        builder.and(store.createdAt.lt(cursor));
+
+        if (keyword != null && !keyword.isEmpty()) {
+            builder.and(
+                    store.name.containsIgnoreCase(keyword)
+                            .or(storeCategory.category.containsIgnoreCase(keyword))
+            );
+        }
+
+        BooleanBuilder regionBuilder = new BooleanBuilder();
+        if (siDo != null) regionBuilder.or(region.siDo.eq(siDo));
+        if (siGunGu != null) regionBuilder.or(region.siGunGu.eq(siGunGu));
+        if (eupMyeongDong != null) regionBuilder.or(region.eupMyeonDong.eq(eupMyeongDong));
+
+        builder.and(regionBuilder);
+
+        List<Store> stores = query.selectFrom(store).join(store.region,region).join(store.storeCategory,storeCategory).fetchJoin()
+                .where(builder).orderBy(store.createdAt.desc()).limit(pageSize+1).fetch();
+        boolean hasNext = stores.size() > pageSize;
+        if(hasNext){
+            stores.remove(pageSize);
+        }
+        return new SliceImpl<>(stores,pageable,hasNext);
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return query.selectFrom(store).where(store.name.eq(name)).fetchFirst() != null;
+    }
+}
+


### PR DESCRIPTION
## 🔘Part

- [x] store-service querydsl 추가

  <br/>
## ➕ 이슈 링크

- #38 

<br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요

mongodb로 조회하기 위해서 querydsl 필요. 
mongodb로 조회하는 엔티티는 모두 querydsl 추가

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>
