### PR TITLE
🔨 [REFACTOR] cart-service 로직 수정

### DIFF
--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/aspect/PerformanceAspect.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/aspect/PerformanceAspect.java
@@ -6,10 +6,6 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
-/**
- * 성능 모니터링을 위한 AOP Aspect
- * Service 레이어의 메서드 실행 시간을 측정합니다.
- */
 @Slf4j
 @Aspect
 @Component

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/aspect/PerformanceAspect.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/aspect/PerformanceAspect.java
@@ -1,0 +1,63 @@
+package com.example.cloudfour.cartservice.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+/**
+ * 성능 모니터링을 위한 AOP Aspect
+ * Service 레이어의 메서드 실행 시간을 측정합니다.
+ */
+@Slf4j
+@Aspect
+@Component
+public class PerformanceAspect {
+
+    @Around("execution(* com.example.cloudfour.cartservice.domain..service..*(..))")
+    public Object measureExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        String methodName = joinPoint.getSignature().toShortString();
+        
+        try {
+            Object result = joinPoint.proceed();
+            long executionTime = System.currentTimeMillis() - startTime;
+            
+            if (executionTime > 1000) {
+                log.warn("느린 메서드 실행: {} - {}ms", methodName, executionTime);
+            } else {
+                log.debug("메서드 실행 완료: {} - {}ms", methodName, executionTime);
+            }
+            
+            return result;
+        } catch (Exception e) {
+            long executionTime = System.currentTimeMillis() - startTime;
+            log.error("메서드 실행 실패: {} - {}ms, 오류: {}", methodName, executionTime, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Around("execution(* com.example.cloudfour.cartservice.client..*(..))")
+    public Object measureClientExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        String methodName = joinPoint.getSignature().toShortString();
+        
+        try {
+            Object result = joinPoint.proceed();
+            long executionTime = System.currentTimeMillis() - startTime;
+            
+            if (executionTime > 2000) {
+                log.warn("느린 외부 서비스 호출: {} - {}ms", methodName, executionTime);
+            } else {
+                log.debug("외부 서비스 호출 완료: {} - {}ms", methodName, executionTime);
+            }
+            
+            return result;
+        } catch (Exception e) {
+            long executionTime = System.currentTimeMillis() - startTime;
+            log.error("외부 서비스 호출 실패: {} - {}ms, 오류: {}", methodName, executionTime, e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/client/StoreClient.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/client/StoreClient.java
@@ -33,10 +33,10 @@ public class StoreClient {
 
         try {
             rt.headForHeaders(BASE + "/stores/exists?storeId=" + storeId);
-            log.debug("스토어 존재 확인 완료: {}", storeId);
+            log.info("스토어 존재 확인 완료: {}", storeId);
             return true;
         } catch (HttpClientErrorException.NotFound e) {
-            log.debug("스토어가 존재하지 않음: {}", storeId);
+            log.info("스토어가 존재하지 않음: {}", storeId);
             return false;
         } catch (Exception e) {
             log.error("스토어 존재 여부 확인 실패: {}", storeId, e);
@@ -53,10 +53,10 @@ public class StoreClient {
 
         try {
             rt.headForHeaders(BASE + "/menus/exists?menuId=" + menuId);
-            log.debug("메뉴 존재 확인 완료: {}", menuId);
+            log.info("메뉴 존재 확인 완료: {}", menuId);
             return true;
         } catch (HttpClientErrorException.NotFound e) {
-            log.debug("메뉴가 존재하지 않음: {}", menuId);
+            log.info("메뉴가 존재하지 않음: {}", menuId);
             return false;
         } catch (Exception e) {
             log.error("메뉴 존재 여부 확인 실패: {}", menuId, e);
@@ -74,7 +74,7 @@ public class StoreClient {
 
         try {
             StoreResponseDTO store = rt.getForObject(BASE + "/stores/{storeId}", StoreResponseDTO.class, storeId);
-            log.debug("스토어 정보 조회 완료: {}", storeId);
+            log.info("스토어 정보 조회 완료: {}", storeId);
             return store;
         } catch (Exception e) {
             log.error("스토어 정보 조회 실패: {}", storeId, e);
@@ -91,7 +91,7 @@ public class StoreClient {
 
         try {
             MenuResponseDTO menu = rt.getForObject(BASE + "/menus/{menuId}", MenuResponseDTO.class, menuId);
-            log.debug("메뉴 정보 조회 완료: {}", menuId);
+            log.info("메뉴 정보 조회 완료: {}", menuId);
             return menu;
         } catch (Exception e) {
             log.error("메뉴 정보 조회 실패: {}", menuId, e);
@@ -113,7 +113,7 @@ public class StoreClient {
                 MenuOptionResponseDTO.class, 
                 menuOptionId
             );
-            log.debug("메뉴 옵션 정보 조회 완료: {}", menuOptionId);
+            log.info("메뉴 옵션 정보 조회 완료: {}", menuOptionId);
             return option;
         } catch (Exception e) {
             log.error("메뉴 옵션 정보 조회 실패: {}", menuOptionId, e);

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/client/StoreClient.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/client/StoreClient.java
@@ -59,7 +59,15 @@ public class StoreClient {
         }
 
         return menuOptionIds.stream()
-                .map(this::menuOptionById)
+                .map(id -> {
+                    try {
+                        return menuOptionById(id);
+                    } catch (Exception e) {
+                        System.err.println("Failed to fetch menu option: " + id + ", error: " + e.getMessage());
+                        return null;
+                    }
+                })
+                .filter(option -> option != null)
                 .toList();
     }
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/client/StoreClient.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/client/StoreClient.java
@@ -4,71 +4,145 @@ import com.example.cloudfour.cartservice.commondto.MenuOptionResponseDTO;
 import com.example.cloudfour.cartservice.commondto.MenuResponseDTO;
 import com.example.cloudfour.cartservice.commondto.StoreResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class StoreClient {
+    
     private final RestTemplate rt;
 
     private static final String BASE = "http://store-service/internal";
 
+    @Retryable(value = {Exception.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     public Boolean existStore(UUID storeId) {
+        if (storeId == null) {
+            log.warn("Store ID가 null입니다");
+            return false;
+        }
+
         try {
             rt.headForHeaders(BASE + "/stores/exists?storeId=" + storeId);
+            log.debug("스토어 존재 확인 완료: {}", storeId);
             return true;
         } catch (HttpClientErrorException.NotFound e) {
+            log.debug("스토어가 존재하지 않음: {}", storeId);
             return false;
+        } catch (Exception e) {
+            log.error("스토어 존재 여부 확인 실패: {}", storeId, e);
+            throw e;
         }
     }
 
+    @Retryable(value = {Exception.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     public Boolean existMenu(UUID menuId) {
+        if (menuId == null) {
+            log.warn("Menu ID가 null입니다");
+            return false;
+        }
+
         try {
             rt.headForHeaders(BASE + "/menus/exists?menuId=" + menuId);
+            log.debug("메뉴 존재 확인 완료: {}", menuId);
             return true;
         } catch (HttpClientErrorException.NotFound e) {
+            log.debug("메뉴가 존재하지 않음: {}", menuId);
             return false;
+        } catch (Exception e) {
+            log.error("메뉴 존재 여부 확인 실패: {}", menuId, e);
+            throw e;
         }
     }
 
+    @Cacheable(value = "stores", key = "#storeId")
+    @Retryable(value = {Exception.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     public StoreResponseDTO storeById(UUID storeId) {
-        return rt.getForObject(BASE + "/stores/{storeId}", StoreResponseDTO.class, storeId);
-    }
+        if (storeId == null) {
+            log.warn("Store ID가 null입니다");
+            return null;
+        }
 
+        try {
+            StoreResponseDTO store = rt.getForObject(BASE + "/stores/{storeId}", StoreResponseDTO.class, storeId);
+            log.debug("스토어 정보 조회 완료: {}", storeId);
+            return store;
+        } catch (Exception e) {
+            log.error("스토어 정보 조회 실패: {}", storeId, e);
+            throw e;
+        }
+    }
+    @Cacheable(value = "menus", key = "#menuId")
+    @Retryable(value = {Exception.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     public MenuResponseDTO menuById(UUID menuId) {
-        return rt.getForObject(BASE +"/menus/{menuId}", MenuResponseDTO.class,menuId);
+        if (menuId == null) {
+            log.warn("Menu ID가 null입니다");
+            return null;
+        }
+
+        try {
+            MenuResponseDTO menu = rt.getForObject(BASE + "/menus/{menuId}", MenuResponseDTO.class, menuId);
+            log.debug("메뉴 정보 조회 완료: {}", menuId);
+            return menu;
+        } catch (Exception e) {
+            log.error("메뉴 정보 조회 실패: {}", menuId, e);
+            throw e;
+        }
     }
 
+    @Cacheable(value = "menuOptions", key = "#menuOptionId")
+    @Retryable(value = {Exception.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     public MenuOptionResponseDTO menuOptionById(UUID menuOptionId) {
-        return rt.getForObject(BASE +"/menus/options/{optionId}/detail", MenuOptionResponseDTO.class, menuOptionId);
-    }
+        if (menuOptionId == null) {
+            log.warn("Menu Option ID가 null입니다");
+            return null;
+        }
 
-    public MenuOptionResponseDTO menuOptionsById(UUID menuOptionId) {
-        return rt.getForObject(BASE +"/menus/options/{optionId}/detail", MenuOptionResponseDTO.class, menuOptionId);
+        try {
+            MenuOptionResponseDTO option = rt.getForObject(
+                BASE + "/menus/options/{optionId}/detail", 
+                MenuOptionResponseDTO.class, 
+                menuOptionId
+            );
+            log.debug("메뉴 옵션 정보 조회 완료: {}", menuOptionId);
+            return option;
+        } catch (Exception e) {
+            log.error("메뉴 옵션 정보 조회 실패: {}", menuOptionId, e);
+            throw e;
+        }
     }
-
     public List<MenuOptionResponseDTO> menuOptionsByIds(List<UUID> menuOptionIds) {
         if (menuOptionIds == null || menuOptionIds.isEmpty()) {
             return List.of();
         }
 
-        return menuOptionIds.stream()
-                .map(id -> {
-                    try {
-                        return menuOptionById(id);
-                    } catch (Exception e) {
-                        System.err.println("Failed to fetch menu option: " + id + ", error: " + e.getMessage());
-                        return null;
-                    }
-                })
+        log.debug("메뉴 옵션 배치 조회 시작: {} 개", menuOptionIds.size());
+
+        List<MenuOptionResponseDTO> results = menuOptionIds.stream()
+                .map(this::safeGetMenuOption)
                 .filter(option -> option != null)
                 .toList();
+
+        log.debug("메뉴 옵션 배치 조회 완료: {}/{} 개 성공", results.size(), menuOptionIds.size());
+        return results;
+    }
+
+    private MenuOptionResponseDTO safeGetMenuOption(UUID menuOptionId) {
+        try {
+            return menuOptionById(menuOptionId);
+        } catch (Exception e) {
+            log.warn("메뉴 옵션 조회 실패: {}, 오류: {}", menuOptionId, e.getMessage());
+            return null;
+        }
     }
 
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/client/StoreClient.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/client/StoreClient.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -37,15 +38,29 @@ public class StoreClient {
     }
 
     public StoreResponseDTO storeById(UUID storeId) {
-        return rt.getForObject(BASE + "/stores/{storeId}", StoreResponseDTO.class, Map.of("storeId", storeId));
+        return rt.getForObject(BASE + "/stores/{storeId}", StoreResponseDTO.class, storeId);
     }
 
     public MenuResponseDTO menuById(UUID menuId) {
-        return rt.getForObject(BASE +"/menus/{menuId}", MenuResponseDTO.class, Map.of("menuId", menuId));
+        return rt.getForObject(BASE +"/menus/{menuId}", MenuResponseDTO.class,menuId);
     }
 
     public MenuOptionResponseDTO menuOptionById(UUID menuOptionId) {
-        return rt.getForObject(BASE +"/menus/options/{optionId}/detail", MenuOptionResponseDTO.class, Map.of("optionId", menuOptionId));
+        return rt.getForObject(BASE +"/menus/options/{optionId}/detail", MenuOptionResponseDTO.class, menuOptionId);
+    }
+
+    public MenuOptionResponseDTO menuOptionsById(UUID menuOptionId) {
+        return rt.getForObject(BASE +"/menus/options/{optionId}/detail", MenuOptionResponseDTO.class, menuOptionId);
+    }
+
+    public List<MenuOptionResponseDTO> menuOptionsByIds(List<UUID> menuOptionIds) {
+        if (menuOptionIds == null || menuOptionIds.isEmpty()) {
+            return List.of();
+        }
+
+        return menuOptionIds.stream()
+                .map(this::menuOptionById)
+                .toList();
     }
 
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/client/UserClient.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/client/UserClient.java
@@ -3,11 +3,17 @@ package com.example.cloudfour.cartservice.client;
 import com.example.cloudfour.cartservice.commondto.UserAddressResponseDTO;
 import com.example.cloudfour.cartservice.commondto.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserClient {
@@ -15,12 +21,80 @@ public class UserClient {
 
     private static final String BASE = "http://user-service/internal/users";
 
+    @Cacheable(value = "userAddresses", key = "#userId")
+    @Retryable(value = {Exception.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     public UserAddressResponseDTO addressById(UUID userId) {
-        return rt.getForObject(BASE + "/addresses/{userId}", UserAddressResponseDTO.class, userId);
+        if (userId == null) {
+            log.warn("User ID가 null입니다");
+            return null;
+        }
+
+        try {
+            log.info("사용자 주소 정보 조회 시작: {}", userId);
+            UserAddressResponseDTO address = rt.getForObject(BASE + "/addresses/{userId}", UserAddressResponseDTO.class, userId);
+            
+            if (address != null) {
+                log.info("사용자 주소 정보 조회 완료: {} - {}", userId, address.getAddress());
+            } else {
+                log.warn("사용자 주소 정보가 null입니다: {}", userId);
+            }
+            
+            return address;
+        } catch (HttpClientErrorException.NotFound e) {
+            log.warn("사용자 주소 정보를 찾을 수 없습니다: {}", userId);
+            return null;
+        } catch (Exception e) {
+            log.error("사용자 주소 정보 조회 실패: {}", userId, e);
+            throw e;
+        }
     }
 
-    public UserResponseDTO userById(UUID userId){
-        return rt.getForObject(BASE + "/{userId}", UserResponseDTO.class, userId);
+    @Cacheable(value = "users", key = "#userId")
+    @Retryable(value = {Exception.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
+    public UserResponseDTO userById(UUID userId) {
+        if (userId == null) {
+            log.warn("User ID가 null입니다");
+            return null;
+        }
+
+        try {
+            log.info("사용자 정보 조회 시작: {}", userId);
+            UserResponseDTO user = rt.getForObject(BASE + "/{userId}", UserResponseDTO.class, userId);
+            
+            if (user != null) {
+                log.info("사용자 정보 조회 완료: {} - {}", userId, user.getEmail());
+            } else {
+                log.warn("사용자 정보가 null입니다: {}", userId);
+            }
+            
+            return user;
+        } catch (HttpClientErrorException.NotFound e) {
+            log.warn("사용자 정보를 찾을 수 없습니다: {}", userId);
+            return null;
+        } catch (Exception e) {
+            log.error("사용자 정보 조회 실패: {}", userId, e);
+            throw e;
+        }
     }
 
+    @Retryable(value = {Exception.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
+    public Boolean existUser(UUID userId) {
+        if (userId == null) {
+            log.warn("User ID가 null입니다");
+            return false;
+        }
+
+        try {
+            log.info("사용자 존재 확인 시작: {}", userId);
+            rt.headForHeaders(BASE + "/exists?userId=" + userId);
+            log.info("사용자 존재 확인 완료: {}", userId);
+            return true;
+        } catch (HttpClientErrorException.NotFound e) {
+            log.info("사용자가 존재하지 않습니다: {}", userId);
+            return false;
+        } catch (Exception e) {
+            log.error("사용자 존재 여부 확인 실패: {}", userId, e);
+            throw e;
+        }
+    }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/client/UserClient.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/client/UserClient.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.Map;
 import java.util.UUID;
 
 @Component
@@ -17,11 +16,11 @@ public class UserClient {
     private static final String BASE = "http://user-service/internal/users";
 
     public UserAddressResponseDTO addressById(UUID userId) {
-        return rt.getForObject(BASE + "/addresses/{userId}", UserAddressResponseDTO.class, Map.of("userId", userId));
+        return rt.getForObject(BASE + "/addresses/{userId}", UserAddressResponseDTO.class, userId);
     }
 
     public UserResponseDTO userById(UUID userId){
-        return rt.getForObject(BASE + "/{userId}", UserResponseDTO.class, Map.of("userId", userId));
+        return rt.getForObject(BASE + "/{userId}", UserResponseDTO.class, userId);
     }
 
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/config/CacheConfig.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/config/CacheConfig.java
@@ -16,8 +16,10 @@ public class CacheConfig {
     public CacheManager cacheManager() {
         return new ConcurrentMapCacheManager(
             "stores",
-            "menus",
-            "menuOptions"
+            "menus", 
+            "menuOptions",
+            "users",
+            "userAddresses"
         );
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/config/CacheConfig.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/config/CacheConfig.java
@@ -1,0 +1,23 @@
+package com.example.cloudfour.cartservice.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableCaching
+@EnableRetry
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager(
+            "stores",
+            "menus",
+            "menuOptions"
+        );
+    }
+}

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/config/RestTemplateConfig.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/config/RestTemplateConfig.java
@@ -7,8 +7,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
-import java.time.Duration;
-
 @Configuration
 public class RestTemplateConfig {
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/controller/CartController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/controller/CartController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,7 +33,7 @@ public class CartController {
     @PostMapping
     @Operation(summary = "장바구니 생성", description = "장바구니를 생성합니다. 장바구니 생성에 사용되는 API입니다.")
     public CustomResponse<CartResponseDTO.CartCreateResponseDTO> createCart(
-            @RequestBody CartRequestDTO.CartCreateRequestDTO cartCreateRequestDTO,
+            @Valid @RequestBody CartRequestDTO.CartCreateRequestDTO cartCreateRequestDTO,
             @AuthenticationPrincipal CurrentUser user
     ){
         CartResponseDTO.CartCreateResponseDTO cart = cartCommandService.createCart(cartCreateRequestDTO,user);

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/converter/CartConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/converter/CartConverter.java
@@ -1,9 +1,9 @@
 package com.example.cloudfour.cartservice.domain.cart.converter;
 
-
 import com.example.cloudfour.cartservice.domain.cart.controller.CartCommonResponseDTO;
 import com.example.cloudfour.cartservice.domain.cart.dto.CartResponseDTO;
 import com.example.cloudfour.cartservice.domain.cart.entity.Cart;
+import com.example.cloudfour.cartservice.domain.cartitem.converter.CartItemConverter;
 
 import java.util.UUID;
 
@@ -11,6 +11,9 @@ public class CartConverter {
     public static CartResponseDTO.CartDetailResponseDTO toCartDetailResponseDTO(Cart cart) {
         return CartResponseDTO.CartDetailResponseDTO.builder()
                 .cartCommonResponseDTO(toCartCommonResponseDTO(cart))
+                .cartItems(cart.getCartItems().stream()
+                        .map(CartItemConverter::toCartItemListResponseDTO)
+                        .toList())
                 .build();
     }
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/converter/CartConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/converter/CartConverter.java
@@ -4,20 +4,34 @@ import com.example.cloudfour.cartservice.domain.cart.controller.CartCommonRespon
 import com.example.cloudfour.cartservice.domain.cart.dto.CartResponseDTO;
 import com.example.cloudfour.cartservice.domain.cart.entity.Cart;
 import com.example.cloudfour.cartservice.domain.cartitem.converter.CartItemConverter;
+import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemResponseDTO;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
-public class CartConverter {
+public final class CartConverter {
+
+    private CartConverter() {
+        throw new UnsupportedOperationException("유틸리티 클래스를 인스턴스화할 수 없습니다");
+    }
+
     public static CartResponseDTO.CartDetailResponseDTO toCartDetailResponseDTO(Cart cart) {
+        validateCartNotNull(cart, "toCartDetailResponseDTO");
+        
+        List<CartItemResponseDTO.CartItemListResponseDTO> cartItemDtos = 
+            convertCartItemsToDto(cart);
+
         return CartResponseDTO.CartDetailResponseDTO.builder()
                 .cartCommonResponseDTO(toCartCommonResponseDTO(cart))
-                .cartItems(cart.getCartItems().stream()
-                        .map(CartItemConverter::toCartItemListResponseDTO)
-                        .toList())
+                .cartItems(cartItemDtos)
                 .build();
     }
 
     public static CartResponseDTO.CartCreateResponseDTO toCartCreateResponseDTO(Cart cart, UUID cartItemId) {
+        validateCartNotNull(cart, "toCartCreateResponseDTO");
+        validateCartItemIdNotNull(cartItemId);
+
         return CartResponseDTO.CartCreateResponseDTO.builder()
                 .cartCommonResponseDTO(toCartCommonResponseDTO(cart))
                 .cartItemId(cartItemId)
@@ -25,11 +39,37 @@ public class CartConverter {
                 .build();
     }
 
-    public static CartCommonResponseDTO toCartCommonResponseDTO(Cart cart){
+    public static CartCommonResponseDTO toCartCommonResponseDTO(Cart cart) {
+        validateCartNotNull(cart, "toCartCommonResponseDTO");
+
         return CartCommonResponseDTO.builder()
                 .cartId(cart.getId())
                 .userId(cart.getUser())
                 .storeId(cart.getStore())
                 .build();
+    }
+
+    private static void validateCartNotNull(Cart cart, String methodName) {
+        if (cart == null) {
+            throw new IllegalArgumentException(
+                String.format("카트는 %s 단위로 null일 수 없습니다", methodName)
+            );
+        }
+    }
+
+    private static void validateCartItemIdNotNull(UUID cartItemId) {
+        if (cartItemId == null) {
+            throw new IllegalArgumentException("CartItem ID는 null일 수 없습니다");
+        }
+    }
+
+    private static List<CartItemResponseDTO.CartItemListResponseDTO> convertCartItemsToDto(Cart cart) {
+        if (cart.getCartItems() == null || cart.getCartItems().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return cart.getCartItems().stream()
+                .map(CartItemConverter::toCartItemListResponseDTO)
+                .toList();
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/dto/CartRequestDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/dto/CartRequestDTO.java
@@ -1,5 +1,7 @@
 package com.example.cloudfour.cartservice.domain.cart.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,9 +11,15 @@ import java.util.UUID;
 public class CartRequestDTO {
     @Getter
     @Builder
-    public static class CartCreateRequestDTO{
-        UUID storeId;
-        UUID menuId;
-        List<UUID> menuOptionIds;
+    public static class CartCreateRequestDTO {
+        
+        @NotNull(message = "스토어 ID는 필수입니다")
+        private UUID storeId;
+        
+        @NotNull(message = "메뉴 ID는 필수입니다")
+        private UUID menuId;
+        
+        @Size(max = 10, message = "메뉴 옵션은 최대 10개까지 선택할 수 있습니다")
+        private List<UUID> menuOptionIds;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/dto/CartRequestDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/dto/CartRequestDTO.java
@@ -3,6 +3,7 @@ package com.example.cloudfour.cartservice.domain.cart.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.UUID;
 
 public class CartRequestDTO {
@@ -11,6 +12,6 @@ public class CartRequestDTO {
     public static class CartCreateRequestDTO{
         UUID storeId;
         UUID menuId;
-        UUID menuOptionId;
+        List<UUID> menuOptionIds;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/dto/CartResponseDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/dto/CartResponseDTO.java
@@ -1,11 +1,13 @@
 package com.example.cloudfour.cartservice.domain.cart.dto;
 
 import com.example.cloudfour.cartservice.domain.cart.controller.CartCommonResponseDTO;
+import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemResponseDTO;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public class CartResponseDTO {
@@ -23,5 +25,6 @@ public class CartResponseDTO {
     public static class CartDetailResponseDTO {
         @JsonUnwrapped
         CartCommonResponseDTO cartCommonResponseDTO;
+        List<CartItemResponseDTO.CartItemListResponseDTO> cartItems;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/entity/Cart.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/entity/Cart.java
@@ -13,25 +13,31 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * 장바구니 엔티티
+ * 사용자별로 스토어의 상품들을 담을 수 있는 컨테이너 역할
+ */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@Table(name="p_cart")
+@Table(name = "p_cart")
 public class Cart {
+    
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @CreationTimestamp
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    @Column(name = "userId" ,nullable = false)
+    @Column(name = "userId", nullable = false)
     private UUID user;
 
     @Column(nullable = false)
@@ -42,32 +48,73 @@ public class Cart {
     @Builder.Default
     private boolean storeIsDeleted = false;
 
-    @Column(name = "storeId" ,nullable = false)
+    @Column(name = "storeId", nullable = false)
     private UUID store;
 
-    @OneToMany(mappedBy = "cart", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "cart", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<CartItem> cartItems = new ArrayList<>();
 
-    public static class CartBuilder{
-        private CartBuilder id(UUID id){
-            throw new CartException(CartErrorCode.CREATE_FAILED);
+    public void addCartItem(CartItem cartItem) {
+        if (cartItem == null) {
+            throw new CartException(CartErrorCode.INVALID_INPUT);
         }
+        cartItem.setCart(this);
+        this.cartItems.add(cartItem);
     }
 
-    public void setUser(UUID user){
+    public void removeCartItem(UUID cartItemId) {
+        if (cartItemId == null) {
+            throw new CartException(CartErrorCode.INVALID_INPUT);
+        }
+        this.cartItems.removeIf(item -> item.getId().equals(cartItemId));
+    }
+
+    public void clearCart() {
+        this.cartItems.clear();
+    }
+
+    public int getItemCount() {
+        return this.cartItems.size();
+    }
+
+    public boolean isEmpty() {
+        return this.cartItems.isEmpty();
+    }
+
+    public void setUser(UUID user) {
+        if (user == null) {
+            throw new CartException(CartErrorCode.INVALID_INPUT);
+        }
         this.user = user;
     }
 
-    public void setStore(UUID store){
+    public void setStore(UUID store) {
+        if (store == null) {
+            throw new CartException(CartErrorCode.INVALID_INPUT);
+        }
         this.store = store;
     }
 
-    public void setUserIsDeleted(){
+    public void setUserIsDeleted() {
         this.userIsDeleted = true;
     }
 
-    public void setStoreIsDeleted(){
+    public void setStoreIsDeleted() {
         this.storeIsDeleted = true;
+    }
+
+    public void setCartItems(List<CartItem> cartItems) {
+        if (cartItems == null) {
+            throw new CartException(CartErrorCode.INVALID_INPUT);
+        }
+        this.cartItems.clear();
+        this.cartItems.addAll(cartItems);
+    }
+
+    public static class CartBuilder {
+        private CartBuilder id(UUID id) {
+            throw new CartException(CartErrorCode.CREATE_FAILED);
+        }
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/entity/Cart.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/entity/Cart.java
@@ -3,8 +3,21 @@ package com.example.cloudfour.cartservice.domain.cart.entity;
 import com.example.cloudfour.cartservice.domain.cart.exception.CartErrorCode;
 import com.example.cloudfour.cartservice.domain.cart.exception.CartException;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
-import jakarta.persistence.*;
-import lombok.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -13,10 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * 장바구니 엔티티
- * 사용자별로 스토어의 상품들을 담을 수 있는 컨테이너 역할
- */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/exception/CartErrorCode.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/exception/CartErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum CartErrorCode implements BaseErrorCode {
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "CART400_0", "잘못된 입력값입니다."),
     CREATE_FAILED(HttpStatus.BAD_REQUEST, "CART400_1", "장바구니 정보를 생성할 수 없습니다."),
     DELETE_FAILED(HttpStatus.BAD_REQUEST, "CART400_2", "장바구니 정보를 삭제할 수 없습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "CART401", "장바구니에 접근할 수 있는 권한이 없습니다."),

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/repository/CartRepository.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/repository/CartRepository.java
@@ -5,10 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface CartRepository extends JpaRepository<Cart, UUID> {
+
     @Query("select c from Cart c where c.id = :cartId and c.user = :userId")
     Optional<Cart> findByIdAndUser(@Param("cartId") UUID cartId, @Param("userId") UUID userId);
 
@@ -18,6 +20,12 @@ public interface CartRepository extends JpaRepository<Cart, UUID> {
     @Query("select count(c) > 0 from Cart c where c.user = :userId and c.store = :storeId")
     boolean existsByUserAndStore(@Param("userId") UUID userId, @Param("storeId") UUID storeId);
 
-    @Query("select count(c) > 0 from Cart c where c.id =:cartId and c.user =:userId")
+    @Query("select count(c) > 0 from Cart c where c.id = :cartId and c.user = :userId")
     boolean existsByUserAndCart(@Param("userId") UUID userId, @Param("cartId") UUID cartId);
+
+    @Query("select c from Cart c where c.user = :userId")
+    List<Cart> findAllByUserId(@Param("userId") UUID userId);
+
+    @Query("select c from Cart c where c.store = :storeId")
+    List<Cart> findAllByStoreId(@Param("storeId") UUID storeId);
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/repository/CartRepository.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/repository/CartRepository.java
@@ -12,6 +12,9 @@ public interface CartRepository extends JpaRepository<Cart, UUID> {
     @Query("select c from Cart c where c.id = :cartId and c.user = :userId")
     Optional<Cart> findByIdAndUser(@Param("cartId") UUID cartId, @Param("userId") UUID userId);
 
+    @Query("select c from Cart c left join fetch c.cartItems where c.id = :cartId and c.user = :userId")
+    Optional<Cart> findByIdAndUserWithCartItems(@Param("cartId") UUID cartId, @Param("userId") UUID userId);
+
     @Query("select count(c) > 0 from Cart c where c.user = :userId and c.store = :storeId")
     boolean existsByUserAndStore(@Param("userId") UUID userId, @Param("storeId") UUID storeId);
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/command/CartCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/command/CartCommandService.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -48,7 +49,7 @@ public class CartCommandService {
         cart.setStore(store);
         Cart savedCart = cartRepository.save(cart);
         MenuResponseDTO menu = storeClient.menuById(cartCreateRequestDTO.getMenuId());
-        CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO = CartItemConverter.toCartItemAddRequestDTO(cartCreateRequestDTO,menu.getPrice());
+        CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO = CartItemConverter.toCartItemAddRequestDTO(cartCreateRequestDTO, menu.getPrice());
         CartItemResponseDTO.CartItemAddResponseDTO cartItemAddResponseDTO = cartItemCommandService.CreateCartItem(cartItemAddRequestDTO, savedCart.getId(), user);
         log.info("장바구니 생성 완료, cartId={}", savedCart.getId());
         return CartConverter.toCartCreateResponseDTO(savedCart,cartItemAddResponseDTO.getCartItemCommonResponseDTO().getCartItemId());

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/command/CartCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/command/CartCommandService.java
@@ -26,47 +26,91 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional
 public class CartCommandService {
+
     private final CartRepository cartRepository;
     private final CartItemCommandService cartItemCommandService;
     private final StoreClient storeClient;
 
-    public CartResponseDTO.CartCreateResponseDTO createCart(CartRequestDTO.CartCreateRequestDTO cartCreateRequestDTO, CurrentUser user) {
-        UUID store = cartCreateRequestDTO.getStoreId();
-        if (!storeClient.existStore(store)) {
-            throw new CartException(CartErrorCode.STORE_NOT_FOUND);
-        }
-        boolean exists = cartRepository.existsByUserAndStore(user.id(), store);
+    public CartResponseDTO.CartCreateResponseDTO createCart(
+            CartRequestDTO.CartCreateRequestDTO req, 
+            CurrentUser user
+    ) {
+        validateUser(user);
+        validateStoreExists(req.getStoreId());
+        validateNoDuplicateCart(user.id(), req.getStoreId());
 
-        if (exists) {
-            log.warn("이미 존재하는 장바구니");
-            throw new CartException(CartErrorCode.ALREADY_ADD);
-        }
-        log.info("장바구니 생성 권한 확인 완료 성공");
-
-        Cart cart = Cart.builder()
-                .build();
-        cart.setUser(user.id());
-        cart.setStore(store);
+        Cart cart = createCartEntity(user.id(), req.getStoreId());
         Cart savedCart = cartRepository.save(cart);
-        MenuResponseDTO menu = storeClient.menuById(cartCreateRequestDTO.getMenuId());
-        CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO = CartItemConverter.toCartItemAddRequestDTO(cartCreateRequestDTO, menu.getPrice());
-        CartItemResponseDTO.CartItemAddResponseDTO cartItemAddResponseDTO = cartItemCommandService.CreateCartItem(cartItemAddRequestDTO, savedCart.getId(), user);
-        log.info("장바구니 생성 완료, cartId={}", savedCart.getId());
-        return CartConverter.toCartCreateResponseDTO(savedCart,cartItemAddResponseDTO.getCartItemCommonResponseDTO().getCartItemId());
+
+        MenuResponseDTO menu = storeClient.menuById(req.getMenuId());
+        CartItemRequestDTO.CartItemAddRequestDTO cartItemReq = 
+            CartItemConverter.toCartItemAddRequestDTO(req, menu.getPrice());
+        
+        CartItemResponseDTO.CartItemAddResponseDTO cartItemResponse = 
+            cartItemCommandService.CreateCartItem(cartItemReq, savedCart.getId(), user);
+
+        log.info("장바구니 생성 완료 (cartId={}, cartItemId={})", 
+            savedCart.getId(), cartItemResponse.getCartItemCommonResponseDTO().getCartItemId());
+        
+        return CartConverter.toCartCreateResponseDTO(
+            savedCart, 
+            cartItemResponse.getCartItemCommonResponseDTO().getCartItemId()
+        );
     }
 
     public void deleteCart(UUID cartId, CurrentUser user) {
+        validateUser(user);
+        
         Cart cart = cartRepository.findById(cartId)
                 .orElseThrow(() -> {
-                    log.warn("존재하지 않는 장바구니");
+                    log.warn("존재하지 않는 장바구니: {}", cartId);
                     return new CartException(CartErrorCode.NOT_FOUND);
                 });
-        log.info("장바구니 삭제 권한 확인 성공");
-        if (!cart.getUser().equals(user.id())) {
-            log.warn("장바구니 삭제 권한 없음");
+
+        validateCartOwnership(cart, user.id());
+        
+        cartRepository.delete(cart);
+        log.info("장바구니 삭제 완료 (cartId={})", cartId);
+    }
+
+    private void validateUser(CurrentUser user) {
+        if (user == null || user.id() == null) {
+            log.warn("유효하지 않은 사용자");
             throw new CartException(CartErrorCode.UNAUTHORIZED_ACCESS);
         }
-        cartRepository.delete(cart);
-        log.info("장바구니 삭제 완료");
+    }
+
+    private void validateStoreExists(UUID storeId) {
+        if (storeId == null) {
+            log.warn("Store ID가 null입니다");
+            throw new CartException(CartErrorCode.STORE_NOT_FOUND);
+        }
+        
+        if (!storeClient.existStore(storeId)) {
+            log.warn("존재하지 않는 스토어: {}", storeId);
+            throw new CartException(CartErrorCode.STORE_NOT_FOUND);
+        }
+    }
+
+    private void validateNoDuplicateCart(UUID userId, UUID storeId) {
+        if (cartRepository.existsByUserAndStore(userId, storeId)) {
+            log.warn("이미 존재하는 장바구니 (userId={}, storeId={})", userId, storeId);
+            throw new CartException(CartErrorCode.ALREADY_ADD);
+        }
+    }
+
+    private Cart createCartEntity(UUID userId, UUID storeId) {
+        Cart cart = Cart.builder().build();
+        cart.setUser(userId);
+        cart.setStore(storeId);
+        return cart;
+    }
+
+    private void validateCartOwnership(Cart cart, UUID userId) {
+        if (!userId.equals(cart.getUser())) {
+            log.warn("장바구니 접근 권한 없음 (cartId={}, userId={}, ownerId={})", 
+                cart.getId(), userId, cart.getUser());
+            throw new CartException(CartErrorCode.UNAUTHORIZED_ACCESS);
+        }
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/query/CartQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/query/CartQueryService.java
@@ -6,25 +6,36 @@ import com.example.cloudfour.cartservice.domain.cart.entity.Cart;
 import com.example.cloudfour.cartservice.domain.cart.exception.CartErrorCode;
 import com.example.cloudfour.cartservice.domain.cart.exception.CartException;
 import com.example.cloudfour.cartservice.domain.cart.repository.CartRepository;
+import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
+import com.example.cloudfour.cartservice.domain.cartitem.repository.CartItemRepository;
 import com.example.cloudfour.modulecommon.dto.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CartQueryService {
     private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
 
     public CartResponseDTO.CartDetailResponseDTO getCartListById(UUID cartId, CurrentUser user) {
-        Cart cart = cartRepository.findByIdAndUser(cartId, user.id())
+        Cart cart = cartRepository.findByIdAndUserWithCartItems(cartId, user.id())
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 장바구니");
                     return new CartException(CartErrorCode.NOT_FOUND);
                 });
+
+        List<CartItem> cartItems = cartItemRepository.findAllByCartIdWithOptions(cartId);
+        cart.getCartItems().clear();
+        cart.getCartItems().addAll(cartItems);
+        
         log.info("장바구니 목록 조회 권한 확인 성공");
         return CartConverter.toCartDetailResponseDTO(cart);
     }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/query/CartQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cart/service/query/CartQueryService.java
@@ -22,21 +22,56 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CartQueryService {
+
     private final CartRepository cartRepository;
     private final CartItemRepository cartItemRepository;
 
     public CartResponseDTO.CartDetailResponseDTO getCartListById(UUID cartId, CurrentUser user) {
-        Cart cart = cartRepository.findByIdAndUserWithCartItems(cartId, user.id())
+        validateUser(user);
+        validateCartId(cartId);
+
+        Cart cart = findCartWithOwnershipValidation(cartId, user.id());
+        List<CartItem> cartItemsWithOptions = loadCartItemsWithOptions(cartId);
+
+        replaceCartItems(cart, cartItemsWithOptions);
+        
+        log.info("장바구니 조회 완료 (cartId={}, itemCount={})", cartId, cartItemsWithOptions.size());
+        return CartConverter.toCartDetailResponseDTO(cart);
+    }
+
+
+    private void validateUser(CurrentUser user) {
+        if (user == null || user.id() == null) {
+            log.warn("유효하지 않은 사용자");
+            throw new CartException(CartErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private void validateCartId(UUID cartId) {
+        if (cartId == null) {
+            log.warn("Cart ID가 null입니다");
+            throw new CartException(CartErrorCode.NOT_FOUND);
+        }
+    }
+
+    private Cart findCartWithOwnershipValidation(UUID cartId, UUID userId) {
+        return cartRepository.findByIdAndUserWithCartItems(cartId, userId)
                 .orElseThrow(() -> {
-                    log.warn("존재하지 않는 장바구니");
+                    log.warn("존재하지 않는 장바구니 또는 접근 권한 없음 (cartId={}, userId={})", cartId, userId);
                     return new CartException(CartErrorCode.NOT_FOUND);
                 });
+    }
 
+    private List<CartItem> loadCartItemsWithOptions(UUID cartId) {
         List<CartItem> cartItems = cartItemRepository.findAllByCartIdWithOptions(cartId);
+        log.debug("CartItem 옵션과 함께 로드 완료 (cartId={}, itemCount={})", cartId, cartItems.size());
+        return cartItems;
+    }
+
+    private void replaceCartItems(Cart cart, List<CartItem> newCartItems) {
         cart.getCartItems().clear();
-        cart.getCartItems().addAll(cartItems);
-        
-        log.info("장바구니 목록 조회 권한 확인 성공");
-        return CartConverter.toCartDetailResponseDTO(cart);
+        if (!newCartItems.isEmpty()) {
+            cart.getCartItems().addAll(newCartItems);
+        }
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemCommonResponseDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemCommonResponseDTO.java
@@ -3,6 +3,7 @@ package com.example.cloudfour.cartservice.domain.cartitem.controller;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.UUID;
 
 @Builder
@@ -10,7 +11,15 @@ import java.util.UUID;
 public class CartItemCommonResponseDTO {
     UUID cartItemId;
     UUID cartId;
-    UUID menuOptionId;
+    List<MenuOptionDto> menuOptions;
     Integer quantity;
     Integer price;
+    
+    @Getter
+    @Builder
+    public static class MenuOptionDto {
+        private UUID id;
+        private Integer additionalPrice;
+        private String optionName;
+    }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import jakarta.validation.Valid;
 
 import java.util.UUID;
 
@@ -36,7 +37,7 @@ public class CartItemController {
     @Operation(summary = "장바구니 항목 추가", description = "장바구니 항목을 추가합니다. 장바구니 항목 추가에 사용되는 API입니다.")
     public CustomResponse<CartItemResponseDTO.CartItemAddResponseDTO> addCartItem(
             @PathVariable("cartId") UUID cartId,
-            @RequestBody CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO,
+            @Valid @RequestBody CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO,
             @AuthenticationPrincipal CurrentUser user
     ){
         CartItemResponseDTO.CartItemAddResponseDTO cartItem = cartItemCommandService.AddCartItem(cartItemAddRequestDTO, cartId, user);
@@ -57,7 +58,7 @@ public class CartItemController {
     @Operation(summary = "장바구니 항목, 옵션 수정", description = "장바구니 항목, 옵션을 수정합니다. 장바구니 항목, 옵션 수정에 사용되는 API입니다.")
     public CustomResponse<CartItemResponseDTO.CartItemUpdateResponseDTO> updateCartItem(
             @PathVariable("cartItemId") UUID cartItemId,
-            @RequestBody CartItemRequestDTO.CartItemUpdateRequestDTO request,
+            @Valid @RequestBody CartItemRequestDTO.CartItemUpdateRequestDTO request,
             @AuthenticationPrincipal CurrentUser user
     ){
         log.info("CartItem 수정 요청 - cartItemId: {}, request: menuOptionIds={}, quantity={}", 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -35,10 +34,10 @@ public class CartItemController {
     @Operation(summary = "장바구니 항목 추가", description = "장바구니 항목을 추가합니다. 장바구니 항목 추가에 사용되는 API입니다.")
     public CustomResponse<CartItemResponseDTO.CartItemAddResponseDTO> addCartItem(
             @PathVariable("cartId") UUID cartId,
-            @RequestBody CartItemRequestDTO.CartItemCreateRequestDTO cartItemCreateRequestDTO,
+            @RequestBody CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO,
             @AuthenticationPrincipal CurrentUser user
     ){
-        CartItemResponseDTO.CartItemAddResponseDTO cartItem = cartItemCommandService.AddCartItem(cartItemCreateRequestDTO, cartId, user);
+        CartItemResponseDTO.CartItemAddResponseDTO cartItem = cartItemCommandService.AddCartItem(cartItemAddRequestDTO, cartId, user);
         return CustomResponse.onSuccess(HttpStatus.CREATED, cartItem);
     }
 
@@ -49,16 +48,6 @@ public class CartItemController {
             @AuthenticationPrincipal CurrentUser user
     ){
         CartItemResponseDTO.CartItemListResponseDTO cartItem = cartItemIdQueryService.getCartItemById(cartItemId,user);
-        return CustomResponse.onSuccess(HttpStatus.OK, cartItem);
-    }
-
-    @GetMapping("/{cartId}/list")
-    @Operation(summary = "장바구니 목록 조회", description = "장바구니 목록을 조회합니다. 장바구니 목록 조회에 사용되는 API입니다.")
-    public CustomResponse<List<CartItemResponseDTO.CartItemListResponseDTO>> getCartItemList(
-            @PathVariable("cartId") UUID cartId,
-            @AuthenticationPrincipal CurrentUser user
-    ){
-        List<CartItemResponseDTO.CartItemListResponseDTO> cartItem = cartItemIdQueryService.getCartItemList(cartId,user);
         return CustomResponse.onSuccess(HttpStatus.OK, cartItem);
     }
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/controller/CartItemController.java
@@ -9,6 +9,7 @@ import com.example.cloudfour.modulecommon.dto.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,6 +26,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/cartItems")
 @RequiredArgsConstructor
+@Slf4j
 @Tag(name = "CartItem", description = "장바구니아이템 API by 조성칠")
 public class CartItemController {
     private final CartItemCommandService cartItemCommandService;
@@ -58,6 +60,9 @@ public class CartItemController {
             @RequestBody CartItemRequestDTO.CartItemUpdateRequestDTO request,
             @AuthenticationPrincipal CurrentUser user
     ){
+        log.info("CartItem 수정 요청 - cartItemId: {}, request: menuOptionIds={}, quantity={}", 
+            cartItemId, request.getMenuOptionIds(), request.getQuantity());
+        
         CartItemResponseDTO.CartItemUpdateResponseDTO cartItem = cartItemCommandService.updateCartItem(request, cartItemId, user);
         return CustomResponse.onSuccess(HttpStatus.OK, cartItem);
     }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/converter/CartItemConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/converter/CartItemConverter.java
@@ -6,6 +6,9 @@ import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemRequestDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemResponseDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
 
+import java.util.List;
+import java.util.UUID;
+
 public class CartItemConverter {
 
     public static CartItemResponseDTO.CartItemAddResponseDTO toCartItemAddResponseDTO(CartItem cartItem) {
@@ -29,19 +32,30 @@ public class CartItemConverter {
     }
 
     public static CartItemRequestDTO.CartItemAddRequestDTO toCartItemAddRequestDTO(CartRequestDTO.CartCreateRequestDTO cartCreateRequestDTO, int price){
-        return   CartItemRequestDTO.CartItemAddRequestDTO.builder()
+        List<UUID> menuOptionIds = cartCreateRequestDTO.getMenuOptionIds();
+        
+        return CartItemRequestDTO.CartItemAddRequestDTO.builder()
                 .menuId(cartCreateRequestDTO.getMenuId())
-                .menuOptionId(cartCreateRequestDTO.getMenuOptionId())
-                .quantity(1)
-                .price(price)
+                .menuOptionIds(menuOptionIds)
                 .build();
     }
 
     public static CartItemCommonResponseDTO toCartItemCommonResponseDTO(CartItem cartItem){
+        List<CartItemCommonResponseDTO.MenuOptionDto> menuOptions = null;
+        if (cartItem.getOptions() != null && !cartItem.getOptions().isEmpty()) {
+            menuOptions = cartItem.getOptions().stream()
+                .map(option -> CartItemCommonResponseDTO.MenuOptionDto.builder()
+                    .id(option.getMenuOptionId())
+                    .additionalPrice(option.getAdditionalPrice())
+                    .optionName(option.getOptionName())
+                    .build())
+                .toList();
+        }
+        
         return CartItemCommonResponseDTO.builder()
                 .cartItemId(cartItem.getId())
                 .cartId(cartItem.getCart().getId())
-                .menuOptionId(cartItem.getMenuOption())
+                .menuOptions(menuOptions)
                 .quantity(cartItem.getQuantity())
                 .price(cartItem.getPrice())
                 .build();

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/converter/CartItemConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/converter/CartItemConverter.java
@@ -5,13 +5,22 @@ import com.example.cloudfour.cartservice.domain.cartitem.controller.CartItemComm
 import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemRequestDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemResponseDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
+import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItemOption;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-public class CartItemConverter {
+
+public final class CartItemConverter {
+
+    private CartItemConverter() {
+        throw new UnsupportedOperationException("유틸리티 클래스를 인스턴스화할 수 없습니다.");
+    }
 
     public static CartItemResponseDTO.CartItemAddResponseDTO toCartItemAddResponseDTO(CartItem cartItem) {
+        validateCartItemNotNull(cartItem, "toCartItemAddResponseDTO");
+
         return CartItemResponseDTO.CartItemAddResponseDTO.builder()
                 .menuId(cartItem.getMenu())
                 .cartItemCommonResponseDTO(toCartItemCommonResponseDTO(cartItem))
@@ -19,20 +28,31 @@ public class CartItemConverter {
     }
 
     public static CartItemResponseDTO.CartItemUpdateResponseDTO toCartItemUpdateResponseDTO(CartItem cartItem) {
+        validateCartItemNotNull(cartItem, "toCartItemUpdateResponseDTO");
+
         return CartItemResponseDTO.CartItemUpdateResponseDTO.builder()
                 .cartItemCommonResponseDTO(toCartItemCommonResponseDTO(cartItem))
                 .build();
     }
 
     public static CartItemResponseDTO.CartItemListResponseDTO toCartItemListResponseDTO(CartItem cartItem) {
+        validateCartItemNotNull(cartItem, "toCartItemListResponseDTO");
+
         return CartItemResponseDTO.CartItemListResponseDTO.builder()
                 .menuId(cartItem.getMenu())
                 .cartItemCommonResponseDTO(toCartItemCommonResponseDTO(cartItem))
                 .build();
     }
 
-    public static CartItemRequestDTO.CartItemAddRequestDTO toCartItemAddRequestDTO(CartRequestDTO.CartCreateRequestDTO cartCreateRequestDTO, int price){
-        List<UUID> menuOptionIds = cartCreateRequestDTO.getMenuOptionIds();
+    public static CartItemRequestDTO.CartItemAddRequestDTO toCartItemAddRequestDTO(
+            CartRequestDTO.CartCreateRequestDTO cartCreateRequestDTO, 
+            int price
+    ) {
+        if (cartCreateRequestDTO == null) {
+            throw new IllegalArgumentException("CartCreateRequestDTO cannot be null");
+        }
+
+        List<UUID> menuOptionIds = safeGetMenuOptionIds(cartCreateRequestDTO.getMenuOptionIds());
         
         return CartItemRequestDTO.CartItemAddRequestDTO.builder()
                 .menuId(cartCreateRequestDTO.getMenuId())
@@ -40,17 +60,12 @@ public class CartItemConverter {
                 .build();
     }
 
-    public static CartItemCommonResponseDTO toCartItemCommonResponseDTO(CartItem cartItem){
-        List<CartItemCommonResponseDTO.MenuOptionDto> menuOptions = null;
-        if (cartItem.getOptions() != null && !cartItem.getOptions().isEmpty()) {
-            menuOptions = cartItem.getOptions().stream()
-                .map(option -> CartItemCommonResponseDTO.MenuOptionDto.builder()
-                    .id(option.getMenuOptionId())
-                    .additionalPrice(option.getAdditionalPrice())
-                    .optionName(option.getOptionName())
-                    .build())
-                .toList();
-        }
+    public static CartItemCommonResponseDTO toCartItemCommonResponseDTO(CartItem cartItem) {
+        validateCartItemNotNull(cartItem, "toCartItemCommonResponseDTO");
+        validateCartItemHasCart(cartItem);
+
+        List<CartItemCommonResponseDTO.MenuOptionDto> menuOptions = 
+            convertOptionsToDto(cartItem.getOptions());
         
         return CartItemCommonResponseDTO.builder()
                 .cartItemId(cartItem.getId())
@@ -58,6 +73,48 @@ public class CartItemConverter {
                 .menuOptions(menuOptions)
                 .quantity(cartItem.getQuantity())
                 .price(cartItem.getPrice())
+                .build();
+    }
+
+    private static void validateCartItemNotNull(CartItem cartItem, String methodName) {
+        if (cartItem == null) {
+            throw new IllegalArgumentException(
+                String.format("CartItem은 %s에서 null일 수 없습니다", methodName)
+            );
+        }
+    }
+
+    private static void validateCartItemHasCart(CartItem cartItem) {
+        if (cartItem.getCart() == null) {
+            throw new IllegalArgumentException("CartItem에는 관련된 Cart가 있어야 합니다");
+        }
+    }
+
+    private static List<UUID> safeGetMenuOptionIds(List<UUID> menuOptionIds) {
+        return menuOptionIds != null ? menuOptionIds : Collections.emptyList();
+    }
+
+    private static List<CartItemCommonResponseDTO.MenuOptionDto> convertOptionsToDto(
+            List<CartItemOption> options
+    ) {
+        if (options == null || options.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return options.stream()
+                .map(CartItemConverter::convertOptionToDto)
+                .toList();
+    }
+
+    private static CartItemCommonResponseDTO.MenuOptionDto convertOptionToDto(CartItemOption option) {
+        if (option == null) {
+            return null;
+        }
+
+        return CartItemCommonResponseDTO.MenuOptionDto.builder()
+                .id(option.getMenuOptionId())
+                .additionalPrice(option.getAdditionalPrice())
+                .optionName(option.getOptionName())
                 .build();
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/dto/CartItemRequestDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/dto/CartItemRequestDTO.java
@@ -1,5 +1,9 @@
 package com.example.cloudfour.cartservice.domain.cartitem.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,26 +11,48 @@ import java.util.List;
 import java.util.UUID;
 
 public class CartItemRequestDTO {
+    
     @Getter
     @Builder
     public static class CartItemCreateRequestDTO {
+        
+        @NotNull(message = "메뉴 ID는 필수입니다")
         private UUID menuId;
+        
+        @Size(max = 10, message = "메뉴 옵션은 최대 10개까지 선택할 수 있습니다")
         private List<UUID> menuOptionIds;
+        
+        @NotNull(message = "수량은 필수입니다")
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+        @Max(value = 99, message = "수량은 99개 이하여야 합니다")
         private Integer quantity;
+        
+        @NotNull(message = "가격은 필수입니다")
+        @Min(value = 0, message = "가격은 0원 이상이어야 합니다")
         private Integer price;
     }
 
     @Getter
     @Builder
     public static class CartItemAddRequestDTO {
+        
+        @NotNull(message = "메뉴 ID는 필수입니다")
         private UUID menuId;
+        
+        @Size(max = 10, message = "메뉴 옵션은 최대 10개까지 선택할 수 있습니다")
         private List<UUID> menuOptionIds;
     }
 
     @Getter
     @Builder
     public static class CartItemUpdateRequestDTO {
+        
+        @Size(max = 10, message = "메뉴 옵션은 최대 10개까지 선택할 수 있습니다")
         private List<UUID> menuOptionIds;
+        
+        @NotNull(message = "수량은 필수입니다")
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+        @Max(value = 99, message = "수량은 99개 이하여야 합니다")
         private Integer quantity;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/dto/CartItemRequestDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/dto/CartItemRequestDTO.java
@@ -3,29 +3,30 @@ package com.example.cloudfour.cartservice.domain.cartitem.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.UUID;
 
 public class CartItemRequestDTO {
     @Getter
     @Builder
-    public static class CartItemAddRequestDTO {
+    public static class CartItemCreateRequestDTO {
         private UUID menuId;
-        private UUID menuOptionId;
+        private List<UUID> menuOptionIds;
         private Integer quantity;
         private Integer price;
     }
 
     @Getter
     @Builder
-    public static class CartItemCreateRequestDTO {
+    public static class CartItemAddRequestDTO {
         private UUID menuId;
-        private UUID menuOptionId;
+        private List<UUID> menuOptionIds;
     }
 
     @Getter
     @Builder
     public static class CartItemUpdateRequestDTO {
-        private UUID menuOptionId;
+        private List<UUID> menuOptionIds;
         private Integer quantity;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItem.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItem.java
@@ -10,6 +10,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * 장바구니 아이템 엔티티
+ * 장바구니에 담긴 개별 상품과 옵션 정보를 관리
+ */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,8 +21,9 @@ import java.util.UUID;
 @Builder
 @Table(name = "p_cartitem")
 public class CartItem {
+    
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(nullable = false)
@@ -28,50 +33,86 @@ public class CartItem {
     private Integer price;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "cartId" ,nullable = false)
+    @JoinColumn(name = "cartId", nullable = false)
     private Cart cart;
 
-    @Column(name = "menuId" ,nullable = false)
+    @Column(name = "menuId", nullable = false)
     private UUID menu;
 
     @OneToMany(mappedBy = "cartItem", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<CartItemOption> options = new ArrayList<>();
 
-    public static class CartItemBuilder{
-        private CartItemBuilder id(UUID id){
-            throw new CartItemException(CartItemErrorCode.CREATE_FAILED);
+    public void update(Integer quantity, Integer price) {
+        if (quantity != null && quantity > 0) {
+            this.quantity = quantity;
+        }
+        if (price != null && price >= 0) {
+            this.price = price;
         }
     }
 
-    public void setCart(Cart cart){
+    public void increaseQuantity(int increment) {
+        if (increment > 0) {
+            this.quantity += increment;
+        }
+    }
+
+    public void decreaseQuantity(int decrement) {
+        if (decrement > 0 && this.quantity > decrement) {
+            this.quantity -= decrement;
+        }
+    }
+
+    public void addOption(CartItemOption option) {
+        if (option == null) {
+            throw new CartItemException(CartItemErrorCode.INVALID_INPUT);
+        }
+        option.setCartItem(this);
+        this.options.add(option);
+    }
+
+    public void removeOption(UUID optionId) {
+        if (optionId == null) {
+            throw new CartItemException(CartItemErrorCode.INVALID_INPUT);
+        }
+        this.options.removeIf(option -> option.getMenuOptionId().equals(optionId));
+    }
+
+    public void clearOptions() {
+        this.options.clear();
+    }
+
+    public int getOptionCount() {
+        return this.options.size();
+    }
+
+    public boolean hasOptions() {
+        return !this.options.isEmpty();
+    }
+
+    public int getTotalPrice() {
+        return this.quantity * this.price;
+    }
+
+    public void setCart(Cart cart) {
+        if (cart == null) {
+            throw new CartItemException(CartItemErrorCode.INVALID_INPUT);
+        }
         this.cart = cart;
         cart.getCartItems().add(this);
     }
 
-    public void setMenu(UUID menu){
+    public void setMenu(UUID menu) {
+        if (menu == null) {
+            throw new CartItemException(CartItemErrorCode.INVALID_INPUT);
+        }
         this.menu = menu;
     }
 
-    public void setMenuOption(UUID menuOptionId) {
-        CartItemOption option = CartItemOption.builder()
-                .menuOptionId(menuOptionId)
-                .additionalPrice(0)
-                .optionName("")
-                .build();
-        addOption(option);
-    }
-
-    public void addOption(CartItemOption option) {
-        if (option != null) {
-            option.setCartItem(this);
-            this.options.add(option);
+    public static class CartItemBuilder {
+        private CartItemBuilder id(UUID id) {
+            throw new CartItemException(CartItemErrorCode.CREATE_FAILED);
         }
     }
-
-    public void update(Integer quantity, Integer price){
-        if (quantity != null) this.quantity = quantity;
-        if(price != null) this.price = price;
-    }
-
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItem.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItem.java
@@ -3,17 +3,28 @@ package com.example.cloudfour.cartservice.domain.cartitem.entity;
 import com.example.cloudfour.cartservice.domain.cart.entity.Cart;
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemErrorCode;
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemException;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * 장바구니 아이템 엔티티
- * 장바구니에 담긴 개별 상품과 옵션 정보를 관리
- */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItem.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItem.java
@@ -6,6 +6,8 @@ import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemExcep
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -32,8 +34,9 @@ public class CartItem {
     @Column(name = "menuId" ,nullable = false)
     private UUID menu;
 
-    @Column(name = "menuOptionId" ,nullable = true)
-    private UUID menuOption;
+    @OneToMany(mappedBy = "cartItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CartItemOption> options = new ArrayList<>();
 
     public static class CartItemBuilder{
         private CartItemBuilder id(UUID id){
@@ -50,8 +53,18 @@ public class CartItem {
         this.menu = menu;
     }
 
-    public void setMenuOption(UUID menuOption){
-        this.menuOption = menuOption;
+    public void setMenuOption(UUID menuOptionId) {
+        CartItemOption option = CartItemOption.builder()
+                .menuOptionId(menuOptionId)
+                .additionalPrice(0)
+                .optionName("")
+                .build();
+        addOption(option);
+    }
+
+    public void addOption(CartItemOption option) {
+        option.setCartItem(this);
+        this.options.add(option);
     }
 
     public void update(Integer quantity, Integer price){

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItem.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItem.java
@@ -63,8 +63,10 @@ public class CartItem {
     }
 
     public void addOption(CartItemOption option) {
-        option.setCartItem(this);
-        this.options.add(option);
+        if (option != null) {
+            option.setCartItem(this);
+            this.options.add(option);
+        }
     }
 
     public void update(Integer quantity, Integer price){

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItemOption.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItemOption.java
@@ -1,7 +1,5 @@
 package com.example.cloudfour.cartservice.domain.cartitem.entity;
 
-
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItemOption.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItemOption.java
@@ -43,7 +43,7 @@ public class CartItemOption {
     @Column(name = "option_name", nullable = false, length = 100)
     private String optionName;
 
-    void setCartItem(CartItem cartItem) {
+    public void setCartItem(CartItem cartItem) {
         this.cartItem = cartItem;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItemOption.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/entity/CartItemOption.java
@@ -1,0 +1,50 @@
+package com.example.cloudfour.cartservice.domain.cartitem.entity;
+
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "p_cartitem_option")
+public class CartItemOption {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "cartitem_id", nullable = false)
+    private CartItem cartItem;
+
+    @Column(name = "menuoption_id", nullable = false, columnDefinition = "uuid")
+    private UUID menuOptionId;
+
+    @Column(name = "additional_price", nullable = false)
+    private Integer additionalPrice;
+
+    @Column(name = "option_name", nullable = false, length = 100)
+    private String optionName;
+
+    void setCartItem(CartItem cartItem) {
+        this.cartItem = cartItem;
+    }
+}
+

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/exception/CartItemErrorCode.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/exception/CartItemErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum CartItemErrorCode implements BaseErrorCode {
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "CARTITEM400_0", "잘못된 입력값입니다."),
     CREATE_FAILED(HttpStatus.BAD_REQUEST, "CARTITEM400_1", "장바구니 아이템 정보를 생성할 수 없습니다."),
     UPDATE_FAILED(HttpStatus.BAD_REQUEST, "CARTITEM400_2", "장바구니 아이템 정보를 수정할 수 없습니다."),
     DELETE_FAILED(HttpStatus.BAD_REQUEST, "CARTITEM400_3", "장바구니 아이템 정보를 삭제할 수 없습니다."),

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/exception/CartItemErrorCode.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/exception/CartItemErrorCode.java
@@ -14,6 +14,8 @@ public enum CartItemErrorCode implements BaseErrorCode {
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "CARTITEM401", "장바구니 아이템에 접근할 수 있는 권한이 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "CARTITEM404", "장바구니 아이템을 찾을 수 없습니다."),
     ALREADY_ADD(HttpStatus.CONFLICT, "CARTITEM409", "이미 등록된 장바구니 아이템입니다."),
+    INVALID_OPTION(HttpStatus.BAD_REQUEST, "CARTITEM400_4", "유효하지 않은 메뉴 옵션입니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "CARTITEM400_5", "유효하지 않은 수량입니다."),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CARTITEM500", "장바구니 아이템 처리 중 서버 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/repository/CartItemRepository.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/repository/CartItemRepository.java
@@ -6,10 +6,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CartItemRepository extends JpaRepository<CartItem, UUID> {
-    @Query("select count(ci) > 0  from CartItem ci join fetch Cart c on ci.cart.id = c.id where ci.id =:cartItemId and c.user =:userId")
+    @Query("select count(ci) > 0 from CartItem ci where ci.id = :cartItemId and ci.cart.user = :userId")
     boolean existsByCartItemAndUser(@Param("cartItemId") UUID cartItemId, @Param("userId") UUID userId);
     
     @Query("select ci from CartItem ci left join fetch ci.options where ci.cart.id = :cartId")
@@ -17,4 +18,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, UUID> {
     
     @Query("select ci from CartItem ci left join fetch ci.options where ci.cart.id = :cartId and ci.menu = :menuId")
     List<CartItem> findByCartIdAndMenuId(@Param("cartId") UUID cartId, @Param("menuId") UUID menuId);
+    
+    @Query("select ci from CartItem ci left join fetch ci.options where ci.id = :cartItemId")
+    Optional<CartItem> findByIdWithOptions(@Param("cartItemId") UUID cartItemId);
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/repository/CartItemRepository.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/repository/CartItemRepository.java
@@ -14,4 +14,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, UUID> {
     
     @Query("select ci from CartItem ci left join fetch ci.options where ci.cart.id = :cartId")
     List<CartItem> findAllByCartIdWithOptions(@Param("cartId") UUID cartId);
+    
+    @Query("select ci from CartItem ci left join fetch ci.options where ci.cart.id = :cartId and ci.menu = :menuId")
+    List<CartItem> findByCartIdAndMenuId(@Param("cartId") UUID cartId, @Param("menuId") UUID menuId);
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/repository/CartItemRepository.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/repository/CartItemRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public interface CartItemRepository extends JpaRepository<CartItem, UUID> {
     @Query("select count(ci) > 0  from CartItem ci join fetch Cart c on ci.cart.id = c.id where ci.id =:cartItemId and c.user =:userId")
     boolean existsByCartItemAndUser(@Param("cartItemId") UUID cartItemId, @Param("userId") UUID userId);
-
-    @Query("select ci from CartItem ci join fetch Cart c on ci.cart.id = c.id where c.id =:cartId and c.user =:userId")
-    List<CartItem> findAllByCartId(@Param("cartId") UUID cartId,  @Param("userId") UUID userId);
+    
+    @Query("select ci from CartItem ci left join fetch ci.options where ci.cart.id = :cartId")
+    List<CartItem> findAllByCartIdWithOptions(@Param("cartId") UUID cartId);
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
@@ -9,6 +9,7 @@ import com.example.cloudfour.cartservice.domain.cartitem.converter.CartItemConve
 import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemRequestDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemResponseDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
+import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItemOption;
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemErrorCode;
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemException;
 import com.example.cloudfour.cartservice.domain.cartitem.repository.CartItemRepository;
@@ -20,128 +21,101 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItemOption;
+import java.util.*;
+import java.util.Comparator;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 @Transactional
 public class CartItemCommandService {
+
     private final CartItemRepository cartItemRepository;
     private final CartRepository cartRepository;
     private final StoreClient storeClient;
 
-    public CartItemResponseDTO.CartItemAddResponseDTO CreateCartItem(CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO, UUID cartId, CurrentUser user) {
-        Cart cart = cartRepository.findByIdAndUser(cartId, user.id())
-                .orElseThrow(() -> {
-                    log.warn("존재하지 않는 장바구니");
-                    return new CartException(CartErrorCode.NOT_FOUND);
-                });
-
-        if(user==null){
+    public CartItemResponseDTO.CartItemAddResponseDTO CreateCartItem(
+            CartItemRequestDTO.CartItemAddRequestDTO req,
+            UUID cartId,
+            CurrentUser user
+    ) {
+        if (user == null) {
             log.warn("장바구니 아이템 추가 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-
-
-        if (!storeClient.existMenu(cartItemAddRequestDTO.getMenuId())) {
-            throw new CartException(CartErrorCode.MENU_NOT_FOUND);
-        }
-
-        MenuResponseDTO menu = storeClient.menuById(cartItemAddRequestDTO.getMenuId());
-
-        log.info("장바구니 아이템 추가 권한 확인 성공");
-
-        List<UUID> selectedOptionIds =
-                Optional.ofNullable(cartItemAddRequestDTO.getMenuOptionIds()).orElseGet(List::of);
-        
-        int additionalPrice = 0;
-        if (!selectedOptionIds.isEmpty()) {
-            List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
-            additionalPrice = options.stream()
-                    .mapToInt(MenuOptionResponseDTO::getAdditionalPrice)
-                    .sum();
-        }
-
-        List<CartItem> existingCartItems = cartItemRepository.findByCartIdAndMenuId(cartId, menu.getMenuId());
-        
-        for (CartItem existingItem : existingCartItems) {
-            if (isSameOptions(existingItem.getOptions(), selectedOptionIds.isEmpty() ? List.of() : storeClient.menuOptionsByIds(selectedOptionIds))) {
-                int newQuantity = existingItem.getQuantity() + 1;
-                int newTotalPrice = (menu.getPrice() + additionalPrice) * newQuantity;
-                
-                existingItem.update(newQuantity, newTotalPrice);
-                cartItemRepository.save(existingItem);
-                
-                log.info("기존 장바구니 아이템 수량 증가 (cartItemId={}, quantity: {} -> {})", 
-                    existingItem.getId(), existingItem.getQuantity() - 1, existingItem.getQuantity());
-                
-                return CartItemConverter.toCartItemAddResponseDTO(existingItem);
-            }
-        }
-
-        CartItem cartItem = CartItem.builder()
-                .quantity(1)
-                .price(menu.getPrice() + additionalPrice)
-                .build();
-
-        cartItem.setCart(cart);
-        cartItem.setMenu(menu.getMenuId());
-
-        if (!selectedOptionIds.isEmpty()) {
-            List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
-            for (MenuOptionResponseDTO optionResponse : options) {
-                CartItemOption option = CartItemOption.builder()
-                        .menuOptionId(optionResponse.getMenuOptionId())
-                        .additionalPrice(optionResponse.getAdditionalPrice())
-                        .optionName(optionResponse.getOptionName())
-                        .build();
-                cartItem.addOption(option);
-            }
-        }
-
-        cartItemRepository.save(cartItem);
-
-        log.info("새로운 장바구니 아이템 추가 완료");
-        return CartItemConverter.toCartItemAddResponseDTO(cartItem);
-    }
-
-    public CartItemResponseDTO.CartItemAddResponseDTO AddCartItem(CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO, UUID cartId, CurrentUser user) {
         Cart cart = cartRepository.findByIdAndUser(cartId, user.id())
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 장바구니");
                     return new CartException(CartErrorCode.NOT_FOUND);
                 });
 
-        if(user==null){
+        if (!storeClient.existMenu(req.getMenuId())) {
+            throw new CartException(CartErrorCode.MENU_NOT_FOUND);
+        }
+
+        MenuResponseDTO menu = storeClient.menuById(req.getMenuId());
+
+        List<UUID> selectedOptionIds = dedup(req.getMenuOptionIds());
+        List<MenuOptionResponseDTO> options = fetchOptionsOnce(selectedOptionIds);
+
+        validateOptionsBelongToMenu(options, menu.getMenuId());
+
+        int unitPrice = calcUnitPrice(menu.getPrice(), options);
+        int quantity = 1;
+        int totalPrice = unitPrice * quantity;
+
+        List<CartItem> existing = cartItemRepository.findByCartIdAndMenuId(cartId, menu.getMenuId());
+        for (CartItem e : existing) {
+            if (isSameOptions(e.getOptions(), options)) {
+                int newQty = e.getQuantity() + quantity;
+                int newTotal = unitPrice * newQty;
+                e.update(newQty, newTotal);
+                cartItemRepository.save(e);
+                log.info("기존 장바구니 아이템 수량 증가 (cartItemId={}, {} -> {})", e.getId(), newQty - quantity, newQty);
+                return CartItemConverter.toCartItemAddResponseDTO(e);
+            }
+        }
+
+        CartItem item = CartItem.builder()
+                .quantity(quantity)
+                .price(totalPrice)
+                .build();
+        item.setCart(cart);
+        item.setMenu(menu.getMenuId());
+        attachOptions(item, options);
+
+        cartItemRepository.save(item);
+        log.info("새로운 장바구니 아이템 추가 (cartId={}, itemId={})", cart.getId(), item.getId());
+
+        return cartItemRepository.findByIdWithOptions(item.getId())
+                .map(CartItemConverter::toCartItemAddResponseDTO)
+                .orElseGet(() -> CartItemConverter.toCartItemAddResponseDTO(item));
+    }
+
+    public CartItemResponseDTO.CartItemAddResponseDTO AddCartItem(
+            CartItemRequestDTO.CartItemAddRequestDTO req,
+            UUID cartId,
+            CurrentUser user
+    ) {
+        if (user == null) {
             log.warn("장바구니 아이템 생성 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
-        log.info("장바구니 아이템 생성 권한 확인 성공");
 
-        MenuResponseDTO menu = storeClient.menuById(cartItemAddRequestDTO.getMenuId());
-        log.info("메뉴 데이터 가져옴: {}", menu.getMenuId());
+        Cart cart = cartRepository.findByIdAndUser(cartId, user.id())
+                .orElseThrow(() -> {
+                    log.warn("존재하지 않는 장바구니");
+                    return new CartException(CartErrorCode.NOT_FOUND);
+                });
 
-        List<UUID> selectedOptionIds =
-                Optional.ofNullable(cartItemAddRequestDTO.getMenuOptionIds()).orElseGet(List::of);
+        MenuResponseDTO menu = storeClient.menuById(req.getMenuId());
+        log.info("메뉴 데이터: {}", menu.getMenuId());
 
-        List<MenuOptionResponseDTO> options = selectedOptionIds.isEmpty()
-                ? List.of()
-                : storeClient.menuOptionsByIds(selectedOptionIds);
+        List<UUID> selectedOptionIds = dedup(req.getMenuOptionIds());
+        List<MenuOptionResponseDTO> options = fetchOptionsOnce(selectedOptionIds);
 
-        boolean invalid = options.stream().anyMatch(opt -> !opt.getMenuId().equals(menu.getMenuId()));
-        if (invalid) {
-            log.warn("요청한 옵션 중 메뉴와 소속이 다른 옵션 존재");
-            throw new CartItemException(CartItemErrorCode.INVALID_OPTION);
-        }
-
-        int basePrice = menu.getPrice();
-        int additional = options.stream().mapToInt(MenuOptionResponseDTO::getAdditionalPrice).sum();
-        int unitPrice = basePrice + additional;
+        validateOptionsBelongToMenu(options, menu.getMenuId());
 
         int quantity = 1;
         if (quantity <= 0) {
@@ -149,164 +123,160 @@ public class CartItemCommandService {
             throw new CartItemException(CartItemErrorCode.INVALID_QUANTITY);
         }
 
+        int unitPrice = calcUnitPrice(menu.getPrice(), options);
         int totalPrice = unitPrice * quantity;
 
-        List<CartItem> existingCartItems = cartItemRepository.findByCartIdAndMenuId(cartId, menu.getMenuId());
-        
-        for (CartItem existingItem : existingCartItems) {
-            if (isSameOptions(existingItem.getOptions(), options)) {
-                int newQuantity = existingItem.getQuantity() + quantity;
-                int newTotalPrice = unitPrice * newQuantity;
-                
-                existingItem.update(newQuantity, newTotalPrice);
-                cartItemRepository.save(existingItem);
-                
-                log.info("기존 장바구니 아이템 수량 증가 (cartItemId={}, quantity: {} -> {})", 
-                    existingItem.getId(), existingItem.getQuantity() - quantity, existingItem.getQuantity());
-                
-                return CartItemConverter.toCartItemAddResponseDTO(existingItem);
+        List<CartItem> existing = cartItemRepository.findByCartIdAndMenuId(cartId, menu.getMenuId());
+        for (CartItem e : existing) {
+            if (isSameOptions(e.getOptions(), options)) {
+                int newQty = e.getQuantity() + quantity;
+                int newTotal = unitPrice * newQty;
+                e.update(newQty, newTotal);
+                cartItemRepository.save(e);
+                log.info("기존 장바구니 아이템 수량 증가 (cartItemId={}, {} -> {})", e.getId(), newQty - quantity, newQty);
+                return CartItemConverter.toCartItemAddResponseDTO(e);
             }
         }
 
-        CartItem cartItem = CartItem.builder()
+        CartItem item = CartItem.builder()
                 .quantity(quantity)
                 .price(totalPrice)
                 .build();
+        item.setCart(cart);
+        item.setMenu(menu.getMenuId());
+        attachOptions(item, options);
 
-        cartItem.setCart(cart);
-        cartItem.setMenu(menu.getMenuId());
+        cartItemRepository.save(item);
+        log.info("새로운 장바구니 아이템 생성 완료 (cartId={}, itemId={})", cart.getId(), item.getId());
 
-        for (MenuOptionResponseDTO optionResponse : options) {
-            CartItemOption option = CartItemOption.builder()
-                    .menuOptionId(optionResponse.getMenuOptionId())
-                    .additionalPrice(optionResponse.getAdditionalPrice())
-                    .optionName(optionResponse.getOptionName())
-                    .build();
-            cartItem.addOption(option);
-        }
-
-        cartItemRepository.save(cartItem);
-        log.info("새로운 장바구니 아이템 생성 완료 (cartId={}, itemId={})", cart.getId(), cartItem.getId());
-
-        return CartItemConverter.toCartItemAddResponseDTO(cartItem);
+        return cartItemRepository.findByIdWithOptions(item.getId())
+                .map(CartItemConverter::toCartItemAddResponseDTO)
+                .orElseGet(() -> CartItemConverter.toCartItemAddResponseDTO(item));
     }
 
-    private boolean isSameOptions(List<CartItemOption> existingOptions, List<MenuOptionResponseDTO> newOptions) {
-        if (existingOptions.size() != newOptions.size()) {
-            return false;
-        }
-
-        List<UUID> existingOptionIds = existingOptions.stream()
-                .map(CartItemOption::getMenuOptionId)
-                .sorted()
-                .toList();
-        
-        List<UUID> newOptionIds = newOptions.stream()
-                .map(MenuOptionResponseDTO::getMenuOptionId)
-                .sorted()
-                .toList();
-        
-        return existingOptionIds.equals(newOptionIds);
-    }
-
-    public CartItemResponseDTO.CartItemUpdateResponseDTO updateCartItem(CartItemRequestDTO.CartItemUpdateRequestDTO cartItemUpdateRequestDTO, UUID cartItemId, CurrentUser user) {
-        CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(()->{
+    public CartItemResponseDTO.CartItemUpdateResponseDTO updateCartItem(
+            CartItemRequestDTO.CartItemUpdateRequestDTO req,
+            UUID cartItemId,
+            CurrentUser user
+    ) {
+        CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(() -> {
             log.warn("존재하지 않는 장바구니 아이템");
             return new CartItemException(CartItemErrorCode.NOT_FOUND);
         });
-        if(user == null || !cartItemRepository.existsByCartItemAndUser(cartItemId,user.id())){
+
+        if (user == null || !cartItemRepository.existsByCartItemAndUser(cartItemId, user.id())) {
             log.warn("장바구니 아이템 수정 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        log.info("장바구니 아이템 수정 권한 확인 성공");
-
-        // 요청 데이터 상세 로깅
-        log.info("원본 요청 데이터 - menuOptionIds: {}, quantity: {}", 
-            cartItemUpdateRequestDTO.getMenuOptionIds(), 
-            cartItemUpdateRequestDTO.getQuantity());
-
-        List<UUID> selectedOptionIds =
-                Optional.ofNullable(cartItemUpdateRequestDTO.getMenuOptionIds()).orElseGet(List::of);
-        
-        log.info("처리된 옵션 ID 목록: {}, 수량: {}", selectedOptionIds, cartItemUpdateRequestDTO.getQuantity());
-        
-        int additionalPrice = 0;
-        if (!selectedOptionIds.isEmpty()) {
-            List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
-            log.info("Store에서 가져온 옵션 정보: {}", options.size());
-            additionalPrice = options.stream()
-                    .mapToInt(MenuOptionResponseDTO::getAdditionalPrice)
-                    .sum();
-        }
+        List<UUID> selectedOptionIds = dedup(req.getMenuOptionIds());
+        List<MenuOptionResponseDTO> options = fetchOptionsOnce(selectedOptionIds);
 
         MenuResponseDTO menu = storeClient.menuById(cartItem.getMenu());
 
-        Integer quantity = cartItemUpdateRequestDTO.getQuantity();
-        if(quantity <=0){
-            log.info("수량이 0보다 적으므로 장바구니 수정 취소");
-            throw new CartItemException(CartItemErrorCode.UPDATE_FAILED);
+        Integer quantity = req.getQuantity();
+        if (quantity == null || quantity <= 0) {
+            log.warn("수량이 0 이하: {}", quantity);
+            throw new CartItemException(CartItemErrorCode.INVALID_QUANTITY);
         }
 
-        int totalPrice = (menu.getPrice() + additionalPrice) * quantity;
+        if (!options.isEmpty()) {
+            validateOptionsBelongToMenu(options, menu.getMenuId());
+        }
+
+        int unitPrice = calcUnitPrice(menu.getPrice(), options);
+        int totalPrice = unitPrice * quantity;
+
         cartItem.update(quantity, totalPrice);
 
-        int beforeClearCount = cartItem.getOptions().size();
+        int before = cartItem.getOptions().size();
         cartItem.getOptions().clear();
-        log.info("기존 옵션 삭제 완료 - 삭제된 옵션 개수: {}", beforeClearCount);
-
-        if (!selectedOptionIds.isEmpty()) {
-            List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
-            log.info("새로운 옵션 추가 시작 - 추가할 옵션 개수: {}", options.size());
-            
-            for (MenuOptionResponseDTO optionResponse : options) {
-                CartItemOption option = CartItemOption.builder()
-                        .menuOptionId(optionResponse.getMenuOptionId())
-                        .additionalPrice(optionResponse.getAdditionalPrice())
-                        .optionName(optionResponse.getOptionName())
-                        .build();
-                
-                log.info("옵션 생성 - ID: {}, 이름: {}, 추가가격: {}", 
-                    optionResponse.getMenuOptionId(), 
-                    optionResponse.getOptionName(), 
-                    optionResponse.getAdditionalPrice());
-                
-                cartItem.addOption(option);
-            }
-            
-            log.info("옵션 추가 완료 - 현재 옵션 개수: {}", cartItem.getOptions().size());
-        } else {
-            log.info("추가할 옵션이 없음");
-        }
+        attachOptions(cartItem, options);
+        log.info("옵션 교체: {} -> {}", before, cartItem.getOptions().size());
 
         cartItemRepository.save(cartItem);
 
-        CartItem updatedCartItem = cartItemRepository.findByIdWithOptions(cartItemId)
+        CartItem loaded = cartItemRepository.findByIdWithOptions(cartItemId)
                 .orElseThrow(() -> new CartItemException(CartItemErrorCode.NOT_FOUND));
-        
-        log.info("장바구니 아이템 수정 완료 (옵션 개수: {})", updatedCartItem.getOptions().size());
-        return CartItemConverter.toCartItemUpdateResponseDTO(updatedCartItem);
+        return CartItemConverter.toCartItemUpdateResponseDTO(loaded);
     }
 
     public void deleteCartItem(UUID cartItemId, CurrentUser user) {
-        CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(()->{
+        CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(() -> {
             log.warn("존재하지 않는 장바구니 아이템");
             return new CartItemException(CartItemErrorCode.NOT_FOUND);
         });
-        Cart cart = cartRepository.findById(cartItem.getCart().getId()).orElseThrow(()->{
+
+        Cart cart = cartRepository.findById(cartItem.getCart().getId()).orElseThrow(() -> {
             log.warn("존재하지 않는 장바구니");
             return new CartException(CartErrorCode.NOT_FOUND);
         });
-        if(user == null || !cartItemRepository.existsByCartItemAndUser(cartItemId,user.id())){
+
+        if (user == null || !cartItemRepository.existsByCartItemAndUser(cartItemId, user.id())) {
             log.warn("장바구니 아이템 삭제 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
-        log.info("장바구니 아이템 삭제 권한 확인 성공");
+
         cartItemRepository.delete(cartItem);
         cartItemRepository.flush();
-        if(cart.getCartItems().isEmpty()){
+
+        if (cart.getCartItems().isEmpty()) {
             cartRepository.delete(cart);
         }
         log.info("장바구니 아이템 삭제 완료");
+    }
+
+
+    private List<UUID> dedup(List<UUID> ids) {
+        if (ids == null || ids.isEmpty()) return List.of();
+        return new ArrayList<>(new LinkedHashSet<>(ids));
+    }
+
+    private List<MenuOptionResponseDTO> fetchOptionsOnce(List<UUID> optionIds) {
+        if (optionIds == null || optionIds.isEmpty()) return List.of();
+        return storeClient.menuOptionsByIds(optionIds);
+    }
+
+    private void validateOptionsBelongToMenu(List<MenuOptionResponseDTO> options, UUID menuId) {
+        boolean invalid = options.stream().anyMatch(o -> !menuId.equals(o.getMenuId()));
+        if (invalid) {
+            log.warn("요청한 옵션 중 메뉴와 소속이 다른 옵션 존재");
+            throw new CartItemException(CartItemErrorCode.INVALID_OPTION);
+        }
+    }
+
+    private int calcUnitPrice(int basePrice, List<MenuOptionResponseDTO> options) {
+        int additional = options.stream().mapToInt(MenuOptionResponseDTO::getAdditionalPrice).sum();
+        return basePrice + additional;
+    }
+
+    private void attachOptions(CartItem item, List<MenuOptionResponseDTO> options) {
+        if (options == null || options.isEmpty()) return;
+        for (MenuOptionResponseDTO o : options) {
+            CartItemOption opt = CartItemOption.builder()
+                    .menuOptionId(o.getMenuOptionId())
+                    .additionalPrice(o.getAdditionalPrice())
+                    .optionName(o.getOptionName())
+                    .build();
+            item.addOption(opt);
+        }
+    }
+
+    private boolean isSameOptions(List<CartItemOption> existingOptions, List<MenuOptionResponseDTO> newOptions) {
+        if (existingOptions == null) return newOptions == null || newOptions.isEmpty();
+        if (newOptions == null) return existingOptions.isEmpty();
+        if (existingOptions.size() != newOptions.size()) return false;
+
+        List<UUID> a = existingOptions.stream()
+                .map(CartItemOption::getMenuOptionId)
+                .sorted(Comparator.nullsLast(Comparator.naturalOrder()))
+                .toList();
+
+        List<UUID> b = newOptions.stream()
+                .map(MenuOptionResponseDTO::getMenuOptionId)
+                .sorted(Comparator.nullsLast(Comparator.naturalOrder()))
+                .toList();
+
+        return a.equals(b);
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
@@ -20,7 +20,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItemOption;
 
 @Service
 @Slf4j
@@ -48,18 +51,38 @@ public class CartItemCommandService {
             throw new CartException(CartErrorCode.MENU_NOT_FOUND);
         }
 
-        MenuOptionResponseDTO menuOption = storeClient.menuOptionById(cartItemAddRequestDTO.getMenuOptionId());
-
         log.info("장바구니 아이템 추가 권한 확인 성공");
 
+        List<UUID> selectedOptionIds =
+                Optional.ofNullable(cartItemAddRequestDTO.getMenuOptionIds()).orElseGet(List::of);
+        
+        int additionalPrice = 0;
+        if (!selectedOptionIds.isEmpty()) {
+            List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
+            additionalPrice = options.stream()
+                    .mapToInt(MenuOptionResponseDTO::getAdditionalPrice)
+                    .sum();
+        }
+
         CartItem cartItem = CartItem.builder()
-                .quantity(cartItemAddRequestDTO.getQuantity())
-                .price(cartItemAddRequestDTO.getPrice()+menuOption.getAdditionalPrice())
+                .quantity(1)
+                .price(0 + additionalPrice)
                 .build();
 
         cartItem.setCart(cart);
         cartItem.setMenu(menu);
-        cartItem.setMenuOption(menuOption.getMenuOptionId());
+
+        if (!selectedOptionIds.isEmpty()) {
+            List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
+            for (MenuOptionResponseDTO optionResponse : options) {
+                CartItemOption option = CartItemOption.builder()
+                        .menuOptionId(optionResponse.getMenuOptionId())
+                        .additionalPrice(optionResponse.getAdditionalPrice())
+                        .optionName(optionResponse.getOptionName())
+                        .build();
+                cartItem.addOption(option);
+            }
+        }
 
         cartItemRepository.save(cartItem);
 
@@ -67,7 +90,7 @@ public class CartItemCommandService {
         return CartItemConverter.toCartItemAddResponseDTO(cartItem);
     }
 
-    public CartItemResponseDTO.CartItemAddResponseDTO AddCartItem(CartItemRequestDTO.CartItemCreateRequestDTO cartItemCreateRequestDTO, UUID cartId, CurrentUser user) {
+    public CartItemResponseDTO.CartItemAddResponseDTO AddCartItem(CartItemRequestDTO.CartItemAddRequestDTO cartItemAddRequestDTO, UUID cartId, CurrentUser user) {
         Cart cart = cartRepository.findByIdAndUser(cartId, user.id())
                 .orElseThrow(() -> {
                     log.warn("존재하지 않는 장바구니");
@@ -79,22 +102,55 @@ public class CartItemCommandService {
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
         log.info("장바구니 아이템 생성 권한 확인 성공");
-        MenuResponseDTO menu = storeClient.menuById(cartItemCreateRequestDTO.getMenuId());
-        log.info("메뉴 데이터 가져옴");
-        MenuOptionResponseDTO menuOption = storeClient.menuOptionById(cartItemCreateRequestDTO.getMenuOptionId());
+
+        MenuResponseDTO menu = storeClient.menuById(cartItemAddRequestDTO.getMenuId());
+        log.info("메뉴 데이터 가져옴: {}", menu.getMenuId());
+
+        List<UUID> selectedOptionIds =
+                Optional.ofNullable(cartItemAddRequestDTO.getMenuOptionIds()).orElseGet(List::of);
+
+        List<MenuOptionResponseDTO> options = selectedOptionIds.isEmpty()
+                ? List.of()
+                : storeClient.menuOptionsByIds(selectedOptionIds);
+
+        boolean invalid = options.stream().anyMatch(opt -> !opt.getMenuId().equals(menu.getMenuId()));
+        if (invalid) {
+            log.warn("요청한 옵션 중 메뉴와 소속이 다른 옵션 존재");
+            throw new CartItemException(CartItemErrorCode.INVALID_OPTION);
+        }
+
+        int basePrice = menu.getPrice();
+        int additional = options.stream().mapToInt(MenuOptionResponseDTO::getAdditionalPrice).sum();
+        int unitPrice = basePrice + additional;
+
+        int quantity = 1;
+        if (quantity <= 0) {
+            log.warn("수량이 0 이하: {}", quantity);
+            throw new CartItemException(CartItemErrorCode.INVALID_QUANTITY);
+        }
+
+        int totalPrice = unitPrice * quantity;
 
         CartItem cartItem = CartItem.builder()
-                .quantity(1)
-                .price(menu.getPrice()+menuOption.getAdditionalPrice())
+                .quantity(quantity)
+                .price(totalPrice)
                 .build();
 
         cartItem.setCart(cart);
         cartItem.setMenu(menu.getMenuId());
-        cartItem.setMenuOption(menuOption.getMenuOptionId());
+
+        for (MenuOptionResponseDTO optionResponse : options) {
+            CartItemOption option = CartItemOption.builder()
+                    .menuOptionId(optionResponse.getMenuOptionId())
+                    .additionalPrice(optionResponse.getAdditionalPrice())
+                    .optionName(optionResponse.getOptionName())
+                    .build();
+            cartItem.addOption(option);
+        }
 
         cartItemRepository.save(cartItem);
+        log.info("장바구니 아이템 생성 완료 (cartId={}, itemId={})", cart.getId(), cartItem.getId());
 
-        log.info("장바구니 아이템 생성 완료");
         return CartItemConverter.toCartItemAddResponseDTO(cartItem);
     }
 
@@ -109,9 +165,19 @@ public class CartItemCommandService {
         }
 
         log.info("장바구니 아이템 수정 권한 확인 성공");
-        MenuOptionResponseDTO menuOption = storeClient.menuOptionById(cartItemUpdateRequestDTO.getMenuOptionId());
 
-        MenuResponseDTO menu = storeClient.menuById(menuOption.getMenuId());
+        List<UUID> selectedOptionIds =
+                Optional.ofNullable(cartItemUpdateRequestDTO.getMenuOptionIds()).orElseGet(List::of);
+        
+        int additionalPrice = 0;
+        if (!selectedOptionIds.isEmpty()) {
+            List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
+            additionalPrice = options.stream()
+                    .mapToInt(MenuOptionResponseDTO::getAdditionalPrice)
+                    .sum();
+        }
+
+        MenuResponseDTO menu = storeClient.menuById(cartItem.getMenu());
 
         Integer quantity = cartItemUpdateRequestDTO.getQuantity();
         if(quantity <=0){
@@ -119,8 +185,22 @@ public class CartItemCommandService {
             throw new CartItemException(CartItemErrorCode.UPDATE_FAILED);
         }
 
-        cartItem.update(quantity, quantity*(menu.getPrice()+menuOption.getAdditionalPrice()));
-        cartItem.setMenuOption(menuOption.getMenuOptionId());
+        int totalPrice = (menu.getPrice() + additionalPrice) * quantity;
+        cartItem.update(quantity, totalPrice);
+
+        cartItem.getOptions().clear();
+        if (!selectedOptionIds.isEmpty()) {
+            List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
+            for (MenuOptionResponseDTO optionResponse : options) {
+                CartItemOption option = CartItemOption.builder()
+                        .menuOptionId(optionResponse.getMenuOptionId())
+                        .additionalPrice(optionResponse.getAdditionalPrice())
+                        .optionName(optionResponse.getOptionName())
+                        .build();
+                cartItem.addOption(option);
+            }
+        }
+        
         cartItemRepository.save(cartItem);
         log.info("장바구니 아이템 수정 완료");
         return CartItemConverter.toCartItemUpdateResponseDTO(cartItem);

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
@@ -21,8 +21,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @Slf4j

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
@@ -221,12 +221,20 @@ public class CartItemCommandService {
 
         log.info("장바구니 아이템 수정 권한 확인 성공");
 
+        // 요청 데이터 상세 로깅
+        log.info("원본 요청 데이터 - menuOptionIds: {}, quantity: {}", 
+            cartItemUpdateRequestDTO.getMenuOptionIds(), 
+            cartItemUpdateRequestDTO.getQuantity());
+
         List<UUID> selectedOptionIds =
                 Optional.ofNullable(cartItemUpdateRequestDTO.getMenuOptionIds()).orElseGet(List::of);
+        
+        log.info("처리된 옵션 ID 목록: {}, 수량: {}", selectedOptionIds, cartItemUpdateRequestDTO.getQuantity());
         
         int additionalPrice = 0;
         if (!selectedOptionIds.isEmpty()) {
             List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
+            log.info("Store에서 가져온 옵션 정보: {}", options.size());
             additionalPrice = options.stream()
                     .mapToInt(MenuOptionResponseDTO::getAdditionalPrice)
                     .sum();
@@ -243,22 +251,41 @@ public class CartItemCommandService {
         int totalPrice = (menu.getPrice() + additionalPrice) * quantity;
         cartItem.update(quantity, totalPrice);
 
+        int beforeClearCount = cartItem.getOptions().size();
         cartItem.getOptions().clear();
+        log.info("기존 옵션 삭제 완료 - 삭제된 옵션 개수: {}", beforeClearCount);
+
         if (!selectedOptionIds.isEmpty()) {
             List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
+            log.info("새로운 옵션 추가 시작 - 추가할 옵션 개수: {}", options.size());
+            
             for (MenuOptionResponseDTO optionResponse : options) {
                 CartItemOption option = CartItemOption.builder()
                         .menuOptionId(optionResponse.getMenuOptionId())
                         .additionalPrice(optionResponse.getAdditionalPrice())
                         .optionName(optionResponse.getOptionName())
                         .build();
+                
+                log.info("옵션 생성 - ID: {}, 이름: {}, 추가가격: {}", 
+                    optionResponse.getMenuOptionId(), 
+                    optionResponse.getOptionName(), 
+                    optionResponse.getAdditionalPrice());
+                
                 cartItem.addOption(option);
             }
+            
+            log.info("옵션 추가 완료 - 현재 옵션 개수: {}", cartItem.getOptions().size());
+        } else {
+            log.info("추가할 옵션이 없음");
         }
-        
+
         cartItemRepository.save(cartItem);
-        log.info("장바구니 아이템 수정 완료");
-        return CartItemConverter.toCartItemUpdateResponseDTO(cartItem);
+
+        CartItem updatedCartItem = cartItemRepository.findByIdWithOptions(cartItemId)
+                .orElseThrow(() -> new CartItemException(CartItemErrorCode.NOT_FOUND));
+        
+        log.info("장바구니 아이템 수정 완료 (옵션 개수: {})", updatedCartItem.getOptions().size());
+        return CartItemConverter.toCartItemUpdateResponseDTO(updatedCartItem);
     }
 
     public void deleteCartItem(UUID cartItemId, CurrentUser user) {

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/command/CartItemCommandService.java
@@ -45,11 +45,14 @@ public class CartItemCommandService {
             log.warn("장바구니 아이템 추가 권한 없음");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
-        UUID menu = cartItemAddRequestDTO.getMenuId();
 
-        if (!storeClient.existMenu(menu)) {
+
+
+        if (!storeClient.existMenu(cartItemAddRequestDTO.getMenuId())) {
             throw new CartException(CartErrorCode.MENU_NOT_FOUND);
         }
+
+        MenuResponseDTO menu = storeClient.menuById(cartItemAddRequestDTO.getMenuId());
 
         log.info("장바구니 아이템 추가 권한 확인 성공");
 
@@ -64,13 +67,30 @@ public class CartItemCommandService {
                     .sum();
         }
 
+        List<CartItem> existingCartItems = cartItemRepository.findByCartIdAndMenuId(cartId, menu.getMenuId());
+        
+        for (CartItem existingItem : existingCartItems) {
+            if (isSameOptions(existingItem.getOptions(), selectedOptionIds.isEmpty() ? List.of() : storeClient.menuOptionsByIds(selectedOptionIds))) {
+                int newQuantity = existingItem.getQuantity() + 1;
+                int newTotalPrice = (menu.getPrice() + additionalPrice) * newQuantity;
+                
+                existingItem.update(newQuantity, newTotalPrice);
+                cartItemRepository.save(existingItem);
+                
+                log.info("기존 장바구니 아이템 수량 증가 (cartItemId={}, quantity: {} -> {})", 
+                    existingItem.getId(), existingItem.getQuantity() - 1, existingItem.getQuantity());
+                
+                return CartItemConverter.toCartItemAddResponseDTO(existingItem);
+            }
+        }
+
         CartItem cartItem = CartItem.builder()
                 .quantity(1)
-                .price(0 + additionalPrice)
+                .price(menu.getPrice() + additionalPrice)
                 .build();
 
         cartItem.setCart(cart);
-        cartItem.setMenu(menu);
+        cartItem.setMenu(menu.getMenuId());
 
         if (!selectedOptionIds.isEmpty()) {
             List<MenuOptionResponseDTO> options = storeClient.menuOptionsByIds(selectedOptionIds);
@@ -86,7 +106,7 @@ public class CartItemCommandService {
 
         cartItemRepository.save(cartItem);
 
-        log.info("장바구니 아이템 추가 완료");
+        log.info("새로운 장바구니 아이템 추가 완료");
         return CartItemConverter.toCartItemAddResponseDTO(cartItem);
     }
 
@@ -131,6 +151,23 @@ public class CartItemCommandService {
 
         int totalPrice = unitPrice * quantity;
 
+        List<CartItem> existingCartItems = cartItemRepository.findByCartIdAndMenuId(cartId, menu.getMenuId());
+        
+        for (CartItem existingItem : existingCartItems) {
+            if (isSameOptions(existingItem.getOptions(), options)) {
+                int newQuantity = existingItem.getQuantity() + quantity;
+                int newTotalPrice = unitPrice * newQuantity;
+                
+                existingItem.update(newQuantity, newTotalPrice);
+                cartItemRepository.save(existingItem);
+                
+                log.info("기존 장바구니 아이템 수량 증가 (cartItemId={}, quantity: {} -> {})", 
+                    existingItem.getId(), existingItem.getQuantity() - quantity, existingItem.getQuantity());
+                
+                return CartItemConverter.toCartItemAddResponseDTO(existingItem);
+            }
+        }
+
         CartItem cartItem = CartItem.builder()
                 .quantity(quantity)
                 .price(totalPrice)
@@ -149,9 +186,27 @@ public class CartItemCommandService {
         }
 
         cartItemRepository.save(cartItem);
-        log.info("장바구니 아이템 생성 완료 (cartId={}, itemId={})", cart.getId(), cartItem.getId());
+        log.info("새로운 장바구니 아이템 생성 완료 (cartId={}, itemId={})", cart.getId(), cartItem.getId());
 
         return CartItemConverter.toCartItemAddResponseDTO(cartItem);
+    }
+
+    private boolean isSameOptions(List<CartItemOption> existingOptions, List<MenuOptionResponseDTO> newOptions) {
+        if (existingOptions.size() != newOptions.size()) {
+            return false;
+        }
+
+        List<UUID> existingOptionIds = existingOptions.stream()
+                .map(CartItemOption::getMenuOptionId)
+                .sorted()
+                .toList();
+        
+        List<UUID> newOptionIds = newOptions.stream()
+                .map(MenuOptionResponseDTO::getMenuOptionId)
+                .sorted()
+                .toList();
+        
+        return existingOptionIds.equals(newOptionIds);
     }
 
     public CartItemResponseDTO.CartItemUpdateResponseDTO updateCartItem(CartItemRequestDTO.CartItemUpdateRequestDTO cartItemUpdateRequestDTO, UUID cartItemId, CurrentUser user) {

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/query/CartItemQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/query/CartItemQueryService.java
@@ -10,27 +10,55 @@ import com.example.cloudfour.modulecommon.dto.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CartItemQueryService {
+
     private final CartItemRepository cartItemRepository;
 
     public CartItemResponseDTO.CartItemListResponseDTO getCartItemById(UUID cartItemId, CurrentUser user) {
-        if(user == null || !cartItemRepository.existsByCartItemAndUser(cartItemId,user.id())){
-            log.warn("장바구니 아이템 조회 권한 없음");
+        validateUser(user);
+        validateCartItemId(cartItemId);
+        validateCartItemOwnership(cartItemId, user.id());
+
+        CartItem cartItem = findCartItemWithOptions(cartItemId);
+        
+        log.info("장바구니 아이템 조회 완료 (cartItemId={})", cartItemId);
+        return CartItemConverter.toCartItemListResponseDTO(cartItem);
+    }
+
+    private void validateUser(CurrentUser user) {
+        if (user == null || user.id() == null) {
+            log.warn("유효하지 않은 사용자");
             throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
         }
-        log.info("장바구니 아이템 조회 권한 확인 성공");
-        CartItem cartItem = cartItemRepository.findById(cartItemId)
-                .orElseThrow(()->{
-                    log.warn("존재하지 않는 장바구니 아이템");
+    }
+
+    private void validateCartItemId(UUID cartItemId) {
+        if (cartItemId == null) {
+            log.warn("CartItem ID가 null입니다");
+            throw new CartItemException(CartItemErrorCode.NOT_FOUND);
+        }
+    }
+
+    private void validateCartItemOwnership(UUID cartItemId, UUID userId) {
+        if (!cartItemRepository.existsByCartItemAndUser(cartItemId, userId)) {
+            log.warn("장바구니 아이템 조회 권한 없음 (cartItemId={}, userId={})", cartItemId, userId);
+            throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private CartItem findCartItemWithOptions(UUID cartItemId) {
+        return cartItemRepository.findByIdWithOptions(cartItemId)
+                .orElseThrow(() -> {
+                    log.warn("존재하지 않는 장바구니 아이템: {}", cartItemId);
                     return new CartItemException(CartItemErrorCode.NOT_FOUND);
                 });
-        log.info("장바구니 아이템 조회 완료");
-        return CartItemConverter.toCartItemListResponseDTO(cartItem);
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/query/CartItemQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/cartitem/service/query/CartItemQueryService.java
@@ -1,6 +1,5 @@
 package com.example.cloudfour.cartservice.domain.cartitem.service.query;
 
-import com.example.cloudfour.cartservice.domain.cart.repository.CartRepository;
 import com.example.cloudfour.cartservice.domain.cartitem.converter.CartItemConverter;
 import com.example.cloudfour.cartservice.domain.cartitem.dto.CartItemResponseDTO;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
@@ -8,21 +7,17 @@ import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemError
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemException;
 import com.example.cloudfour.cartservice.domain.cartitem.repository.CartItemRepository;
 import com.example.cloudfour.modulecommon.dto.CurrentUser;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 public class CartItemQueryService {
     private final CartItemRepository cartItemRepository;
-    private final CartRepository cartRepository;
 
     public CartItemResponseDTO.CartItemListResponseDTO getCartItemById(UUID cartItemId, CurrentUser user) {
         if(user == null || !cartItemRepository.existsByCartItemAndUser(cartItemId,user.id())){
@@ -37,20 +32,5 @@ public class CartItemQueryService {
                 });
         log.info("장바구니 아이템 조회 완료");
         return CartItemConverter.toCartItemListResponseDTO(cartItem);
-    }
-
-    public List<CartItemResponseDTO.CartItemListResponseDTO>getCartItemList(UUID cartId, CurrentUser user) {
-        if(user == null || !cartRepository.existsByUserAndCart(user.id(),cartId)){
-            log.warn("장바구니 아이템 목록 조회 권한 없음");
-            throw new CartItemException(CartItemErrorCode.UNAUTHORIZED_ACCESS);
-        }
-        log.info("장바구니 아이템 목록 조회 권한 확인");
-        List<CartItem> cartItem = cartItemRepository.findAllByCartId(cartId,user.id());
-        if(cartItem.isEmpty()){
-            log.warn("존재하지 않는 장바구니 아이템");
-            throw new CartItemException(CartItemErrorCode.NOT_FOUND);
-        }
-        log.info("장바구니 아이템 목록 조회 완료");
-        return cartItem.stream().map(CartItemConverter::toCartItemListResponseDTO).toList();
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/controller/OrderController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/controller/OrderController.java
@@ -55,7 +55,7 @@ public class OrderController {
         return CustomResponse.onSuccess(HttpStatus.OK, order);
     }
 
-    @GetMapping("/detail/{orderItemId}")
+    @GetMapping("/{orderItemId}")
     @Operation(summary = "주문 아이템 상세 조회", description = "주문 아이템을 상세 조회합니다. 주문 아이템 상세 조회에 사용되는 API입니다.")
     public CustomResponse<OrderItemResponseDTO.OrderItemListResponseDTO> getOrderItem(
             @PathVariable("orderItemId") UUID orderItemId,
@@ -95,7 +95,7 @@ public class OrderController {
     @PatchMapping("/{orderId}/status")
     @Operation(summary = "주문 상태 변경", description = "주문 상태를 변경합니다. 주문 상태 변경에 사용되는 API입니다.")
     public CustomResponse<OrderResponseDTO.OrderUpdateResponseDTO>  updateOrderStatus(
-            @RequestBody OrderRequestDTO.OrderUpdateRequestDTO orderUpdateRequestDTO,
+            @Valid @RequestBody OrderRequestDTO.OrderUpdateRequestDTO orderUpdateRequestDTO,
             @PathVariable("orderId") UUID orderId,
             @AuthenticationPrincipal CurrentUser user
     ){

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/controller/OrderController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/controller/OrderController.java
@@ -55,7 +55,7 @@ public class OrderController {
         return CustomResponse.onSuccess(HttpStatus.OK, order);
     }
 
-    @GetMapping("/{orderItemId}")
+    @GetMapping("/detail/{orderItemId}")
     @Operation(summary = "주문 아이템 상세 조회", description = "주문 아이템을 상세 조회합니다. 주문 아이템 상세 조회에 사용되는 API입니다.")
     public CustomResponse<OrderItemResponseDTO.OrderItemListResponseDTO> getOrderItem(
             @PathVariable("orderItemId") UUID orderItemId,

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/controller/OrderController.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/controller/OrderController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import jakarta.validation.Valid;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -37,7 +38,7 @@ public class OrderController {
     @Operation(summary = "주문 생성", description = "주문을 생성합니다. 주문 생성에 사용되는 API입니다.")
     public CustomResponse<OrderResponseDTO.OrderCreateResponseDTO> createOrder(
             @PathVariable("cartId") UUID cartId,
-            @RequestBody OrderRequestDTO.OrderCreateRequestDTO orderCreateRequestDTO,
+            @Valid @RequestBody OrderRequestDTO.OrderCreateRequestDTO orderCreateRequestDTO,
             @AuthenticationPrincipal CurrentUser user
     ){
         OrderResponseDTO.OrderCreateResponseDTO order = orderCommandService.createOrder(orderCreateRequestDTO,cartId,user);

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderConverter.java
@@ -48,6 +48,18 @@ public class OrderConverter {
                 .build();
     }
 
+    public static OrderResponseDTO.OrderDetailResponseDTO toOrderDetailResponseDTO(Order order, List<OrderItemResponseDTO.OrderItemListResponseDTO> orderItems, String storeName) {
+        return OrderResponseDTO.OrderDetailResponseDTO.builder()
+                .storeName(storeName)
+                .orderType(order.getOrderType())
+                .receiptType(order.getReceiptType())
+                .address(order.getAddress())
+                .request(order.getRequest())
+                .items(orderItems)
+                .orderCommonResponseDTO(toOrderCommonResponseDTO(order))
+                .build();
+    }
+
     public static OrderResponseDTO.OrderUserResponseDTO toOrderUserResponseDTO(Order order,String storeName) {
         return OrderResponseDTO.OrderUserResponseDTO.builder()
                 .storeName(storeName)

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderConverter.java
@@ -10,7 +10,11 @@ import com.example.cloudfour.cartservice.domain.order.enums.OrderStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public class OrderConverter {
+public final class OrderConverter {
+
+    private OrderConverter() {
+        throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
     public static Order toOrder(OrderRequestDTO.OrderCreateRequestDTO orderCreateRequestDTO, Integer totalPrice, String address) {
         return Order.builder()
                 .orderType(orderCreateRequestDTO.getOrderType())

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderItemConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderItemConverter.java
@@ -2,25 +2,27 @@ package com.example.cloudfour.cartservice.domain.order.converter;
 
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItemOption;
-import com.example.cloudfour.cartservice.commondto.MenuOptionResponseDTO;
 import com.example.cloudfour.cartservice.domain.order.dto.OrderItemResponseDTO;
 import com.example.cloudfour.cartservice.domain.order.entity.Order;
 import com.example.cloudfour.cartservice.domain.order.entity.OrderItem;
 import com.example.cloudfour.cartservice.domain.order.entity.OrderItemOption;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class OrderItemConverter {
+public final class OrderItemConverter {
+
+    private OrderItemConverter() {
+        throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
     
     public static OrderItemResponseDTO.OrderItemListResponseDTO toOrderItemClassListDTO(OrderItem orderItem) {
-        List<OrderItemResponseDTO.OrderItemOptionDTO> options = orderItem.getOptions().stream()
-                .map(option -> OrderItemResponseDTO.OrderItemOptionDTO.builder()
-                        .menuOptionId(option.getMenuOptionId())
-                        .additionalPrice(option.getAdditionalPrice())
-                        .optionName(option.getOptionName())
-                        .build())
-                .collect(Collectors.toList());
+        if (orderItem == null) {
+            throw new IllegalArgumentException("OrderItem cannot be null");
+        }
+
+        List<OrderItemResponseDTO.OrderItemOptionDTO> options = convertOptionsToDto(orderItem.getOptions());
 
         return OrderItemResponseDTO.OrderItemListResponseDTO.builder()
                 .quantity(orderItem.getQuantity())
@@ -31,6 +33,13 @@ public class OrderItemConverter {
     }
 
     public static OrderItem CartItemtoOrderItem(CartItem cartItem, Order order) {
+        if (cartItem == null) {
+            throw new IllegalArgumentException("CartItem cannot be null");
+        }
+        if (order == null) {
+            throw new IllegalArgumentException("Order cannot be null");
+        }
+
         OrderItem orderItem = OrderItem.builder()
                 .quantity(cartItem.getQuantity())
                 .price(cartItem.getPrice())
@@ -39,23 +48,55 @@ public class OrderItemConverter {
         orderItem.setMenu(cartItem.getMenu());
         orderItem.setOrder(order);
 
-        if (cartItem.getOptions() != null && !cartItem.getOptions().isEmpty()) {
-            CartItemOption firstOption = cartItem.getOptions().get(0);
-            orderItem.setMenuOption(firstOption.getMenuOptionId());
-        }
-
-        if (cartItem.getOptions() != null && !cartItem.getOptions().isEmpty()) {
-            List<OrderItemOption> orderItemOptions = cartItem.getOptions().stream()
-                    .map(cartOption -> OrderItemOption.builder()
-                            .menuOptionId(cartOption.getMenuOptionId())
-                            .additionalPrice(cartOption.getAdditionalPrice())
-                            .optionName(cartOption.getOptionName())
-                            .build())
-                    .collect(Collectors.toList());
-            
+        List<OrderItemOption> orderItemOptions = convertCartItemOptionsToOrderItemOptions(cartItem.getOptions());
+        if (!orderItemOptions.isEmpty()) {
             orderItem.addOptions(orderItemOptions);
         }
         
         return orderItem;
+    }
+
+    private static List<OrderItemResponseDTO.OrderItemOptionDTO> convertOptionsToDto(List<OrderItemOption> options) {
+        if (options == null || options.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return options.stream()
+                .map(OrderItemConverter::convertOptionToDto)
+                .collect(Collectors.toList());
+    }
+
+    private static OrderItemResponseDTO.OrderItemOptionDTO convertOptionToDto(OrderItemOption option) {
+        if (option == null) {
+            return null;
+        }
+
+        return OrderItemResponseDTO.OrderItemOptionDTO.builder()
+                .menuOptionId(option.getMenuOptionId())
+                .additionalPrice(option.getAdditionalPrice())
+                .optionName(option.getOptionName())
+                .build();
+    }
+
+    private static List<OrderItemOption> convertCartItemOptionsToOrderItemOptions(List<CartItemOption> cartItemOptions) {
+        if (cartItemOptions == null || cartItemOptions.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return cartItemOptions.stream()
+                .map(OrderItemConverter::convertCartItemOptionToOrderItemOption)
+                .collect(Collectors.toList());
+    }
+
+    private static OrderItemOption convertCartItemOptionToOrderItemOption(CartItemOption cartItemOption) {
+        if (cartItemOption == null) {
+            return null;
+        }
+
+        return OrderItemOption.builder()
+                .menuOptionId(cartItemOption.getMenuOptionId())
+                .additionalPrice(cartItemOption.getAdditionalPrice())
+                .optionName(cartItemOption.getOptionName())
+                .build();
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderItemConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderItemConverter.java
@@ -1,16 +1,38 @@
 package com.example.cloudfour.cartservice.domain.order.converter;
 
-
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
+import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItemOption;
 import com.example.cloudfour.cartservice.commondto.MenuOptionResponseDTO;
 import com.example.cloudfour.cartservice.domain.order.dto.OrderItemResponseDTO;
 import com.example.cloudfour.cartservice.domain.order.entity.Order;
 import com.example.cloudfour.cartservice.domain.order.entity.OrderItem;
+import com.example.cloudfour.cartservice.domain.order.entity.OrderItemOption;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class OrderItemConverter {
+    
     public static OrderItemResponseDTO.OrderItemListResponseDTO toOrderItemClassListDTO(OrderItem orderItem, MenuOptionResponseDTO option) {
         return OrderItemResponseDTO.OrderItemListResponseDTO.builder()
                 .option(option)
+                .build();
+    }
+
+    public static OrderItemResponseDTO.OrderItemListResponseDTO toOrderItemClassListDTO(OrderItem orderItem) {
+        List<OrderItemResponseDTO.OrderItemOptionDTO> options = orderItem.getOptions().stream()
+                .map(option -> OrderItemResponseDTO.OrderItemOptionDTO.builder()
+                        .menuOptionId(option.getMenuOptionId())
+                        .additionalPrice(option.getAdditionalPrice())
+                        .optionName(option.getOptionName())
+                        .build())
+                .collect(Collectors.toList());
+
+        return OrderItemResponseDTO.OrderItemListResponseDTO.builder()
+                .quantity(orderItem.getQuantity())
+                .price(orderItem.getPrice())
+                .menuId(orderItem.getMenu())
+                .options(options)
                 .build();
     }
 
@@ -19,10 +41,27 @@ public class OrderItemConverter {
                 .quantity(cartItem.getQuantity())
                 .price(cartItem.getPrice())
                 .build();
+        
         orderItem.setMenu(cartItem.getMenu());
         orderItem.setOrder(order);
-        orderItem.setMenuOption(cartItem.getMenuOption());
-        return orderItem;
 
+        if (cartItem.getOptions() != null && !cartItem.getOptions().isEmpty()) {
+            CartItemOption firstOption = cartItem.getOptions().get(0);
+            orderItem.setMenuOption(firstOption.getMenuOptionId());
+        }
+
+        if (cartItem.getOptions() != null && !cartItem.getOptions().isEmpty()) {
+            List<OrderItemOption> orderItemOptions = cartItem.getOptions().stream()
+                    .map(cartOption -> OrderItemOption.builder()
+                            .menuOptionId(cartOption.getMenuOptionId())
+                            .additionalPrice(cartOption.getAdditionalPrice())
+                            .optionName(cartOption.getOptionName())
+                            .build())
+                    .collect(Collectors.toList());
+            
+            orderItem.addOptions(orderItemOptions);
+        }
+        
+        return orderItem;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderItemConverter.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/converter/OrderItemConverter.java
@@ -13,12 +13,6 @@ import java.util.stream.Collectors;
 
 public class OrderItemConverter {
     
-    public static OrderItemResponseDTO.OrderItemListResponseDTO toOrderItemClassListDTO(OrderItem orderItem, MenuOptionResponseDTO option) {
-        return OrderItemResponseDTO.OrderItemListResponseDTO.builder()
-                .option(option)
-                .build();
-    }
-
     public static OrderItemResponseDTO.OrderItemListResponseDTO toOrderItemClassListDTO(OrderItem orderItem) {
         List<OrderItemResponseDTO.OrderItemOptionDTO> options = orderItem.getOptions().stream()
                 .map(option -> OrderItemResponseDTO.OrderItemOptionDTO.builder()

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/dto/OrderItemResponseDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/dto/OrderItemResponseDTO.java
@@ -1,7 +1,6 @@
 package com.example.cloudfour.cartservice.domain.order.dto;
 
-import com.example.cloudfour.cartservice.commondto.MenuOptionResponseDTO;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
 import lombok.Builder;
 import lombok.Getter;
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/dto/OrderItemResponseDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/dto/OrderItemResponseDTO.java
@@ -15,10 +15,6 @@ public class OrderItemResponseDTO {
         Integer quantity;
         Integer price;
         UUID menuId;
-
-        @JsonUnwrapped
-        MenuOptionResponseDTO option;
-
         List<OrderItemOptionDTO> options;
     }
 

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/dto/OrderItemResponseDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/dto/OrderItemResponseDTO.java
@@ -5,13 +5,28 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+import java.util.UUID;
+
 public class OrderItemResponseDTO {
     @Getter
     @Builder
     public static class OrderItemListResponseDTO{
         Integer quantity;
         Integer price;
+        UUID menuId;
+
         @JsonUnwrapped
         MenuOptionResponseDTO option;
+
+        List<OrderItemOptionDTO> options;
+    }
+
+    @Getter
+    @Builder
+    public static class OrderItemOptionDTO {
+        private UUID menuOptionId;
+        private Integer additionalPrice;
+        private String optionName;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/dto/OrderRequestDTO.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/dto/OrderRequestDTO.java
@@ -3,24 +3,35 @@ package com.example.cloudfour.cartservice.domain.order.dto;
 import com.example.cloudfour.cartservice.domain.order.enums.OrderStatus;
 import com.example.cloudfour.cartservice.domain.order.enums.OrderType;
 import com.example.cloudfour.cartservice.domain.order.enums.ReceiptType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.UUID;
-
 public class OrderRequestDTO {
+    
     @Getter
     @Builder
     public static class OrderCreateRequestDTO {
-        OrderType orderType;
-        OrderStatus orderStatus;
-        ReceiptType receiptType;
-        String request;
+        
+        @NotNull(message = "주문 타입은 필수입니다")
+        private OrderType orderType;
+        
+        @NotNull(message = "주문 상태는 필수입니다")
+        private OrderStatus orderStatus;
+        
+        @NotNull(message = "수령 타입은 필수입니다")
+        private ReceiptType receiptType;
+        
+        @Size(max = 500, message = "요청사항은 500자 이하여야 합니다")
+        private String request;
     }
 
     @Getter
     @Builder
     public static class OrderUpdateRequestDTO {
-        OrderStatus newStatus;
+        
+        @NotNull(message = "새로운 주문 상태는 필수입니다")
+        private OrderStatus newStatus;
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/Order.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/Order.java
@@ -20,8 +20,9 @@ import java.util.UUID;
 @Builder
 @Table(name = "p_order")
 public class Order extends BaseEntity {
+    
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Enumerated(EnumType.STRING)
@@ -35,6 +36,7 @@ public class Order extends BaseEntity {
     @Column(nullable = false)
     private String address;
 
+    @Column(length = 500)
     private String request;
 
     @Column(nullable = false)
@@ -54,27 +56,66 @@ public class Order extends BaseEntity {
     @Column(name = "storeId", nullable = false)
     private UUID store;
 
-
-    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<OrderItem> orderItems = new ArrayList<>();
 
-    public static class OrderBuilder{
-        private OrderBuilder id(UUID id) {
-            throw new OrderException(OrderErrorCode.CREATE_FAILED);
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        if (orderStatus == null) {
+            throw new OrderException(OrderErrorCode.INVALID_INPUT);
         }
+        this.status = orderStatus;
     }
 
-    public void setUser(UUID user){
+    public void addOrderItem(OrderItem orderItem) {
+        if (orderItem == null) {
+            throw new OrderException(OrderErrorCode.INVALID_INPUT);
+        }
+        orderItem.setOrder(this);
+        this.orderItems.add(orderItem);
+    }
+
+    public void removeOrderItem(UUID orderItemId) {
+        if (orderItemId == null) {
+            throw new OrderException(OrderErrorCode.INVALID_INPUT);
+        }
+        this.orderItems.removeIf(item -> item.getId().equals(orderItemId));
+    }
+
+    public int getItemCount() {
+        return this.orderItems.size();
+    }
+
+    public boolean isCompleted() {
+        return this.status == OrderStatus.주문완료;
+    }
+
+    public boolean isCancelled() {
+        return this.status == OrderStatus.주문취소;
+    }
+
+    public boolean isInProgress() {
+        return this.status != OrderStatus.주문완료 && this.status != OrderStatus.주문취소;
+    }
+
+
+    public void setUser(UUID user) {
+        if (user == null) {
+            throw new OrderException(OrderErrorCode.INVALID_INPUT);
+        }
         this.user = user;
     }
 
-    public void setStore(UUID store){
+    public void setStore(UUID store) {
+        if (store == null) {
+            throw new OrderException(OrderErrorCode.INVALID_INPUT);
+        }
         this.store = store;
     }
 
-
-    public void updateOrderStatus(OrderStatus orderStatus){
-        this.status = orderStatus;
+    public static class OrderBuilder {
+        private OrderBuilder id(UUID id) {
+            throw new OrderException(OrderErrorCode.CREATE_FAILED);
+        }
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/Order.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/Order.java
@@ -6,8 +6,23 @@ import com.example.cloudfour.cartservice.domain.order.enums.ReceiptType;
 import com.example.cloudfour.cartservice.domain.order.exception.OrderErrorCode;
 import com.example.cloudfour.cartservice.domain.order.exception.OrderException;
 import com.example.cloudfour.modulecommon.entity.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 
 import java.util.ArrayList;
 import java.util.List;

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/OrderItem.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/OrderItem.java
@@ -5,6 +5,8 @@ import com.example.cloudfour.cartservice.domain.order.exception.OrderItemExcepti
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -29,8 +31,14 @@ public class OrderItem {
     @Column(name = "menuId", nullable = false)
     private UUID menu;
 
-    @Column(name = "menuOptionId", nullable = false)
+    // 단일 옵션 (기존 호환성 유지)
+    @Column(name = "menuOptionId")
     private UUID menuOption;
+
+    // 여러 옵션을 위한 새로운 구조
+    @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<OrderItemOption> options = new ArrayList<>();
 
     public static class OrderItemBuilder{
         private OrderItemBuilder id(UUID id){
@@ -50,6 +58,17 @@ public class OrderItem {
     public void setMenuOption(UUID menuOption){
         if (menuOption != null) {
             this.menuOption = menuOption;
+        }
+    }
+
+    public void addOption(OrderItemOption option) {
+        option.setOrderItem(this);
+        this.options.add(option);
+    }
+
+    public void addOptions(List<OrderItemOption> options) {
+        if (options != null) {
+            options.forEach(this::addOption);
         }
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/OrderItem.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/OrderItem.java
@@ -2,8 +2,22 @@ package com.example.cloudfour.cartservice.domain.order.entity;
 
 import com.example.cloudfour.cartservice.domain.order.exception.OrderItemErrorCode;
 import com.example.cloudfour.cartservice.domain.order.exception.OrderItemException;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,11 +45,9 @@ public class OrderItem {
     @Column(name = "menuId", nullable = false)
     private UUID menu;
 
-    // 단일 옵션 (기존 호환성 유지)
     @Column(name = "menuOptionId")
     private UUID menuOption;
 
-    // 여러 옵션을 위한 새로운 구조
     @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<OrderItemOption> options = new ArrayList<>();

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/OrderItemOption.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/entity/OrderItemOption.java
@@ -1,0 +1,47 @@
+package com.example.cloudfour.cartservice.domain.order.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "p_orderitem_option")
+public class OrderItemOption {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "orderitem_id", nullable = false)
+    private OrderItem orderItem;
+
+    @Column(name = "menuoption_id", nullable = false, columnDefinition = "uuid")
+    private UUID menuOptionId;
+
+    @Column(name = "additional_price", nullable = false)
+    private Integer additionalPrice;
+
+    @Column(name = "option_name", nullable = false, length = 100)
+    private String optionName;
+
+    void setOrderItem(OrderItem orderItem) {
+        this.orderItem = orderItem;
+    }
+}

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/enums/OrderStatus.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/enums/OrderStatus.java
@@ -1,5 +1,5 @@
 package com.example.cloudfour.cartservice.domain.order.enums;
 
 public enum OrderStatus {
-    주문접수, 주문확인, 조리중, 배달원배정, 배달중, 배달완료
+    주문접수, 주문확인, 조리중, 배달원배정, 배달중, 배달완료, 주문완료, 주문취소
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/enums/OrderType.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/enums/OrderType.java
@@ -1,5 +1,5 @@
 package com.example.cloudfour.cartservice.domain.order.enums;
 
 public enum OrderType {
-    대면,온라인
+    OFFLINE,ONLINE
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/enums/ReceiptType.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/enums/ReceiptType.java
@@ -1,5 +1,5 @@
 package com.example.cloudfour.cartservice.domain.order.enums;
 
 public enum ReceiptType {
-    포장, 배달
+    TOGO, DELIVERY
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/exception/OrderErrorCode.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/exception/OrderErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum OrderErrorCode implements BaseErrorCode {
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "ORDER400_0", "잘못된 입력값입니다."),
     CREATE_FAILED(HttpStatus.BAD_REQUEST, "ORDER400_1", "주문 정보를 생성할 수 없습니다."),
     UPDATE_FAILED(HttpStatus.BAD_REQUEST, "ORDER400_2", "주문 정보를 수정할 수 없습니다."),
     DELETE_FAILED(HttpStatus.BAD_REQUEST, "ORDER400_3", "주문 정보를 삭제할 수 없습니다."),

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/repository/OrderItemOptionRepository.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/repository/OrderItemOptionRepository.java
@@ -1,0 +1,11 @@
+package com.example.cloudfour.cartservice.domain.order.repository;
+
+import com.example.cloudfour.cartservice.domain.order.entity.OrderItemOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface OrderItemOptionRepository extends JpaRepository<OrderItemOption, UUID> {
+}

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/repository/OrderRepository.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.example.cloudfour.cartservice.domain.order.repository;
 
 import com.example.cloudfour.cartservice.domain.order.entity.Order;
+import com.example.cloudfour.cartservice.domain.order.enums.OrderStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,21 +9,33 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+
 public interface OrderRepository extends JpaRepository<Order, UUID> {
-    @Query("select o from Order o where o.id =:OrderId and o.isDeleted = false")
-    Optional<Order> findById(@Param("OrderId") UUID orderId);
 
-    @Query("select o from Order o where o.user=:userId and o.userIsDeleted= false and o.isDeleted = false and o.createdAt <:cursor order by o.createdAt desc")
-    Slice<Order> findAllByUserId(@Param("userId")  UUID userId, LocalDateTime cursor, Pageable pageable);
+    @Query("select o from Order o where o.id = :orderId and o.isDeleted = false")
+    Optional<Order> findById(@Param("orderId") UUID orderId);
 
-    @Query("select o from Order o where o.store=:StoreId and o.userIsDeleted = false and o.userIsDeleted = false and o.isDeleted = false and o.createdAt <:cursor order by o.createdAt desc")
-    Slice<Order> findAllByStoreId(@Param("StoreId")  UUID storeId, LocalDateTime cursor, Pageable pageable);
+    @Query("select o from Order o where o.user = :userId and o.userIsDeleted = false and o.isDeleted = false and o.createdAt < :cursor order by o.createdAt desc")
+    Slice<Order> findAllByUserId(@Param("userId") UUID userId, @Param("cursor") LocalDateTime cursor, Pageable pageable);
 
-    @Query("select count(o) > 0 from Order o where o.id =:OrderId and o.user =:UserId and o.userIsDeleted = false and o.isDeleted = false")
-    boolean existsByOrderIdAndUserId(@Param("OrderId") UUID orderId, @Param("UserId") UUID userId);
+    @Query("select o from Order o where o.store = :storeId and o.userIsDeleted = false and o.isDeleted = false and o.createdAt < :cursor order by o.createdAt desc")
+    Slice<Order> findAllByStoreId(@Param("storeId") UUID storeId, @Param("cursor") LocalDateTime cursor, Pageable pageable);
+
+    @Query("select count(o) > 0 from Order o where o.id = :orderId and o.user = :userId and o.userIsDeleted = false and o.isDeleted = false")
+    boolean existsByOrderIdAndUserId(@Param("orderId") UUID orderId, @Param("userId") UUID userId);
 
     void deleteAllByCreatedAtBefore(LocalDateTime createdAtBefore);
+
+    @Query("select count(o) from Order o where o.status = :status and o.isDeleted = false")
+    long countByStatus(@Param("status") OrderStatus status);
+
+    @Query("select o from Order o where o.user = :userId and o.status = :status and o.userIsDeleted = false and o.isDeleted = false order by o.createdAt desc")
+    List<Order> findAllByUserIdAndStatus(@Param("userId") UUID userId, @Param("status") OrderStatus status);
+
+    @Query("select o from Order o where o.store = :storeId and o.status = :status and o.userIsDeleted = false and o.isDeleted = false order by o.createdAt desc")
+    List<Order> findAllByStoreIdAndStatus(@Param("storeId") UUID storeId, @Param("status") OrderStatus status);
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/command/OrderCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/command/OrderCommandService.java
@@ -8,7 +8,6 @@ import com.example.cloudfour.cartservice.domain.cart.exception.CartException;
 import com.example.cloudfour.cartservice.domain.cart.repository.CartRepository;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemException;
-import com.example.cloudfour.cartservice.domain.cartitem.repository.CartItemRepository;
 import com.example.cloudfour.cartservice.commondto.UserAddressResponseDTO;
 import com.example.cloudfour.cartservice.domain.order.converter.OrderConverter;
 import com.example.cloudfour.cartservice.domain.order.converter.OrderItemConverter;
@@ -19,6 +18,7 @@ import com.example.cloudfour.cartservice.domain.order.entity.OrderItem;
 import com.example.cloudfour.cartservice.domain.order.enums.OrderStatus;
 import com.example.cloudfour.cartservice.domain.order.exception.OrderErrorCode;
 import com.example.cloudfour.cartservice.domain.order.exception.OrderException;
+import com.example.cloudfour.cartservice.domain.order.repository.OrderItemOptionRepository;
 import com.example.cloudfour.cartservice.domain.order.repository.OrderItemRepository;
 import com.example.cloudfour.cartservice.domain.order.repository.OrderRepository;
 import com.example.cloudfour.modulecommon.dto.CurrentUser;
@@ -37,14 +37,14 @@ import java.util.UUID;
 public class OrderCommandService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
+    private final OrderItemOptionRepository orderItemOptionRepository;
     private final CartRepository cartRepository;
-    private final CartItemRepository cartItemRepository;
     private final StoreClient storeClient;
     private final UserClient userClient;
 
 
     public OrderResponseDTO.OrderCreateResponseDTO createOrder(OrderRequestDTO.OrderCreateRequestDTO orderCreateRequestDTO, UUID cartId, CurrentUser user) {
-        Cart cart = cartRepository.findById(cartId).orElseThrow(()->{
+        Cart cart = cartRepository.findByIdAndUserWithCartItems(cartId, user.id()).orElseThrow(()->{
             log.warn("존재하지 않는 장바구니");
             return new CartException(CartErrorCode.NOT_FOUND);
         });
@@ -57,7 +57,7 @@ public class OrderCommandService {
         if (!storeClient.existStore(store)) {
             throw new CartException(CartErrorCode.STORE_NOT_FOUND);
         }
-        List<CartItem> cartItems = cartItemRepository.findAllByCartId(cartId,user.id());
+        List<CartItem> cartItems = cart.getCartItems();
         if(cartItems.isEmpty()) {
             log.warn("존재하지 않는 장바구니 아이템");
             throw new CartItemException(CartErrorCode.NOT_FOUND);
@@ -74,6 +74,13 @@ public class OrderCommandService {
         log.info("주문 생성 완료. 주문 아이템 생성, 장바구니 삭제 남음");
         List<OrderItem> orderItems = cartItems.stream().map(cartItem -> OrderItemConverter.CartItemtoOrderItem(cartItem, order)).toList();
         orderItemRepository.saveAll(orderItems);
+
+        orderItems.forEach(orderItem -> {
+            if (orderItem.getOptions() != null && !orderItem.getOptions().isEmpty()) {
+                orderItemOptionRepository.saveAll(orderItem.getOptions());
+            }
+        });
+        
         log.info("주문 아이템 생성 완료. 장바구니 삭제 남음");
         cartRepository.delete(cart);
         log.info("장바구니 삭제 완료.");

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/command/OrderCommandService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/command/OrderCommandService.java
@@ -8,6 +8,7 @@ import com.example.cloudfour.cartservice.domain.cart.exception.CartException;
 import com.example.cloudfour.cartservice.domain.cart.repository.CartRepository;
 import com.example.cloudfour.cartservice.domain.cartitem.entity.CartItem;
 import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemException;
+import com.example.cloudfour.cartservice.domain.cartitem.exception.CartItemErrorCode;
 import com.example.cloudfour.cartservice.commondto.UserAddressResponseDTO;
 import com.example.cloudfour.cartservice.domain.order.converter.OrderConverter;
 import com.example.cloudfour.cartservice.domain.order.converter.OrderItemConverter;
@@ -43,78 +44,183 @@ public class OrderCommandService {
     private final UserClient userClient;
 
 
-    public OrderResponseDTO.OrderCreateResponseDTO createOrder(OrderRequestDTO.OrderCreateRequestDTO orderCreateRequestDTO, UUID cartId, CurrentUser user) {
-        Cart cart = cartRepository.findByIdAndUserWithCartItems(cartId, user.id()).orElseThrow(()->{
-            log.warn("존재하지 않는 장바구니");
-            return new CartException(CartErrorCode.NOT_FOUND);
-        });
-        if(user == null || !cartRepository.existsByUserAndCart(user.id(), cartId)){
-            log.warn("주문 생성 권한 없음");
-            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
-        }
-        UserAddressResponseDTO userAddress = userClient.addressById(user.id());
-        UUID store = cart.getStore();
-        if (!storeClient.existStore(store)) {
-            throw new CartException(CartErrorCode.STORE_NOT_FOUND);
-        }
-        List<CartItem> cartItems = cart.getCartItems();
-        if(cartItems.isEmpty()) {
-            log.warn("존재하지 않는 장바구니 아이템");
-            throw new CartItemException(CartErrorCode.NOT_FOUND);
-        }
-        log.info("주문 생성 권한 확인 성공");
-        Integer totalPrice = 0;
-        for (CartItem cartItem : cartItems) {
-            totalPrice += cartItem.getPrice();
-        }
-        Order order = OrderConverter.toOrder(orderCreateRequestDTO,totalPrice,userAddress.getAddress());
-        order.setStore(store);
-        order.setUser(user.id());
-        orderRepository.save(order);
-        log.info("주문 생성 완료. 주문 아이템 생성, 장바구니 삭제 남음");
-        List<OrderItem> orderItems = cartItems.stream().map(cartItem -> OrderItemConverter.CartItemtoOrderItem(cartItem, order)).toList();
-        orderItemRepository.saveAll(orderItems);
+    public OrderResponseDTO.OrderCreateResponseDTO createOrder(
+            OrderRequestDTO.OrderCreateRequestDTO req, 
+            UUID cartId, 
+            CurrentUser user
+    ) {
+        validateUser(user);
+        validateCartId(cartId);
 
-        orderItems.forEach(orderItem -> {
-            if (orderItem.getOptions() != null && !orderItem.getOptions().isEmpty()) {
-                orderItemOptionRepository.saveAll(orderItem.getOptions());
-            }
-        });
+        Cart cart = findCartWithOwnershipValidation(cartId, user.id());
+        UserAddressResponseDTO userAddress = fetchUserAddress(user.id());
+        validateStoreExists(cart.getStore());
+        validateCartItemsNotEmpty(cart.getCartItems());
+
+        int totalPrice = calculateTotalPrice(cart.getCartItems());
         
-        log.info("주문 아이템 생성 완료. 장바구니 삭제 남음");
-        cartRepository.delete(cart);
-        log.info("장바구니 삭제 완료.");
+        Order order = createOrderEntity(req, totalPrice, userAddress.getAddress(), cart.getStore(), user.id());
+        orderRepository.save(order);
+        
+        List<OrderItem> orderItems = createOrderItems(cart.getCartItems(), order);
+        orderItemRepository.saveAll(orderItems);
+        
+        saveOrderItemOptions(orderItems);
+        
+        deleteCart(cart);
+        
+        log.info("주문 생성 완료 (orderId={}, totalPrice={})", order.getId(), totalPrice);
         return OrderConverter.toOrderCreateResponseDTO(order);
     }
 
-    public OrderResponseDTO.OrderUpdateResponseDTO updateOrder(OrderRequestDTO.OrderUpdateRequestDTO orderUpdateRequestDTO, UUID orderId, CurrentUser user) {
-        if(user == null || !orderRepository.existsByOrderIdAndUserId(orderId, user.id())) {
-            log.warn("주문 수정 권한 없음");
-            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
-        }
-        Order order = orderRepository.findById(orderId).orElseThrow(()->{
-            log.warn("존재하지 않는 주문");
-            return new OrderException(OrderErrorCode.NOT_FOUND);
-        });
-        log.info("주문 수정 권한 확인 성공");
-        OrderStatus prev_orderStatus = order.getStatus();
-        order.updateOrderStatus(orderUpdateRequestDTO.getNewStatus());
+    public OrderResponseDTO.OrderUpdateResponseDTO updateOrder(
+            OrderRequestDTO.OrderUpdateRequestDTO req, 
+            UUID orderId, 
+            CurrentUser user
+    ) {
+        validateUser(user);
+        validateOrderId(orderId);
+        validateOrderOwnership(orderId, user.id());
+
+        Order order = findOrderById(orderId);
+        OrderStatus prevStatus = order.getStatus();
+        
+        order.updateOrderStatus(req.getNewStatus());
         orderRepository.save(order);
-        log.info("주문 수정 완료");
-        return OrderConverter.toOrderUpdateResponseDTO(order,prev_orderStatus);
+        
+        log.info("주문 수정 완료 (orderId={}, status: {} -> {})", 
+            orderId, prevStatus, order.getStatus());
+        
+        return OrderConverter.toOrderUpdateResponseDTO(order, prevStatus);
     }
 
     public void deleteOrder(UUID orderId, CurrentUser user) {
-        if(user == null || !orderRepository.existsByOrderIdAndUserId(orderId, user.id())) {
-            log.warn("주문 삭제 권한 없음");
+        validateUser(user);
+        validateOrderId(orderId);
+        validateOrderOwnership(orderId, user.id());
+
+        Order order = findOrderById(orderId);
+        order.softDelete();
+        
+        log.info("주문 삭제 완료 (orderId={})", orderId);
+    }
+
+    private void validateUser(CurrentUser user) {
+        if (user == null || user.id() == null) {
+            log.warn("유효하지 않은 사용자");
             throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
         }
-        Order order = orderRepository.findById(orderId).orElseThrow(()->{
-            log.warn("존재하지 않는 주문");
-            return new OrderException(OrderErrorCode.NOT_FOUND);
-        });
-        log.info("주문 삭제 권한 확인");
-        order.softDelete();
-        log.info("주문 삭제 완료");
+    }
+
+    private void validateCartId(UUID cartId) {
+        if (cartId == null) {
+            log.warn("Cart ID가 null입니다");
+            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private void validateOrderId(UUID orderId) {
+        if (orderId == null) {
+            log.warn("Order ID가 null입니다");
+            throw new OrderException(OrderErrorCode.NOT_FOUND);
+        }
+    }
+
+    private void validateOrderOwnership(UUID orderId, UUID userId) {
+        if (!orderRepository.existsByOrderIdAndUserId(orderId, userId)) {
+            log.warn("주문 접근 권한 없음 (orderId={}, userId={})", orderId, userId);
+            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private Order findOrderById(UUID orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> {
+                    log.warn("존재하지 않는 주문: {}", orderId);
+                    return new OrderException(OrderErrorCode.NOT_FOUND);
+                });
+    }
+
+    private Cart findCartWithOwnershipValidation(UUID cartId, UUID userId) {
+        Cart cart = cartRepository.findByIdAndUserWithCartItems(cartId, userId)
+                .orElseThrow(() -> {
+                    log.warn("존재하지 않는 장바구니 또는 접근 권한 없음 (cartId={}, userId={})", cartId, userId);
+                    return new CartException(CartErrorCode.NOT_FOUND);
+                });
+
+        if (!cartRepository.existsByUserAndCart(userId, cartId)) {
+            log.warn("주문 생성 권한 없음 (cartId={}, userId={})", cartId, userId);
+            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        return cart;
+    }
+
+    private UserAddressResponseDTO fetchUserAddress(UUID userId) {
+        try {
+            return userClient.addressById(userId);
+        } catch (Exception e) {
+            log.error("사용자 주소 조회 실패 (userId={})", userId, e);
+            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private void validateStoreExists(UUID storeId) {
+        if (storeId == null) {
+            log.warn("Store ID가 null입니다");
+            throw new CartException(CartErrorCode.STORE_NOT_FOUND);
+        }
+
+        if (!storeClient.existStore(storeId)) {
+            log.warn("존재하지 않는 스토어: {}", storeId);
+            throw new CartException(CartErrorCode.STORE_NOT_FOUND);
+        }
+    }
+
+    private void validateCartItemsNotEmpty(List<CartItem> cartItems) {
+        if (cartItems == null || cartItems.isEmpty()) {
+            log.warn("장바구니에 아이템이 없습니다");
+            throw new CartItemException(CartItemErrorCode.NOT_FOUND);
+        }
+    }
+
+    private int calculateTotalPrice(List<CartItem> cartItems) {
+        return cartItems.stream()
+                .mapToInt(CartItem::getPrice)
+                .sum();
+    }
+
+    private Order createOrderEntity(
+            OrderRequestDTO.OrderCreateRequestDTO req, 
+            int totalPrice, 
+            String address, 
+            UUID storeId, 
+            UUID userId
+    ) {
+        Order order = OrderConverter.toOrder(req, totalPrice, address);
+        order.setStore(storeId);
+        order.setUser(userId);
+        return order;
+    }
+
+    private List<OrderItem> createOrderItems(List<CartItem> cartItems, Order order) {
+        return cartItems.stream()
+                .map(cartItem -> OrderItemConverter.CartItemtoOrderItem(cartItem, order))
+                .toList();
+    }
+
+    private void saveOrderItemOptions(List<OrderItem> orderItems) {
+        orderItems.stream()
+                .filter(orderItem -> orderItem.getOptions() != null && !orderItem.getOptions().isEmpty())
+                .forEach(orderItem -> orderItemOptionRepository.saveAll(orderItem.getOptions()));
+    }
+
+    private void deleteCart(Cart cart) {
+        try {
+            cartRepository.delete(cart);
+            log.debug("장바구니 삭제 완료 (cartId={})", cart.getId());
+        } catch (Exception e) {
+            log.error("장바구니 삭제 실패 (cartId={})", cart.getId(), e);
+        }
     }
 }

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/query/OrderQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/query/OrderQueryService.java
@@ -51,12 +51,13 @@ public class OrderQueryService {
         log.info("주문 조회 권한 확인 성공");
         List<OrderItem> orderItems =  orderItemRepository.findByOrderId(orderId);
         List<OrderItemResponseDTO.OrderItemListResponseDTO> orderItemDTOS =
-                orderItems.stream().map(orderItem -> {
-                    MenuOptionResponseDTO menuOptionDTO = storeClient.menuOptionById(orderItem.getMenuOption());
-                    return OrderItemConverter.toOrderItemClassListDTO(orderItem, menuOptionDTO);
-                }).toList();
+                orderItems.stream().map(OrderItemConverter::toOrderItemClassListDTO).toList();
+        
+        // store 정보 가져오기
+        StoreResponseDTO store = storeClient.storeById(order.getStore());
+        
         log.info("주문 조회 완료");
-        return OrderConverter.toOrderDetailResponseDTO(order,orderItemDTOS);
+        return OrderConverter.toOrderDetailResponseDTO(order, orderItemDTOS, store.getName());
     }
 
     public OrderItemResponseDTO.OrderItemListResponseDTO getOrderItemById(UUID orderItemId, CurrentUser user){
@@ -69,9 +70,8 @@ public class OrderQueryService {
             throw new OrderItemException(OrderItemErrorCode.UNAUTHORIZED_ACCESS);
         }
         log.info("주문 아이템 조회 권한 확인 성공");
-        MenuOptionResponseDTO menuOptionDTO = storeClient.menuOptionById(orderItem.getMenuOption());
         log.info("주문 아이템 조회 완료");
-        return OrderItemConverter.toOrderItemClassListDTO(orderItem,menuOptionDTO);
+        return OrderItemConverter.toOrderItemClassListDTO(orderItem);
     }
 
     public OrderResponseDTO.OrderUserListResponseDTO getOrderListByUser(CurrentUser user, LocalDateTime cursor, Integer size) {

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/query/OrderQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/query/OrderQueryService.java
@@ -2,7 +2,6 @@ package com.example.cloudfour.cartservice.domain.order.service.query;
 
 import com.example.cloudfour.cartservice.client.StoreClient;
 import com.example.cloudfour.cartservice.client.UserClient;
-import com.example.cloudfour.cartservice.commondto.MenuOptionResponseDTO;
 import com.example.cloudfour.cartservice.commondto.StoreResponseDTO;
 import com.example.cloudfour.cartservice.commondto.UserResponseDTO;
 import com.example.cloudfour.cartservice.domain.order.converter.OrderConverter;

--- a/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/query/OrderQueryService.java
+++ b/cart-service/src/main/java/com/example/cloudfour/cartservice/domain/order/service/query/OrderQueryService.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,32 +33,30 @@ import java.util.UUID;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderQueryService {
+
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
-    private static final LocalDateTime first_cursor = LocalDateTime.now().plusDays(1);
     private final StoreClient storeClient;
     private final UserClient userClient;
 
-    public OrderResponseDTO.OrderDetailResponseDTO getOrderById(UUID orderId , CurrentUser user) {
-        Order order = orderRepository.findById(orderId).orElseThrow(()->{
-            log.warn("존재하지 않는 주문");
-            return new OrderException(OrderErrorCode.NOT_FOUND);
-        });
-        if(user == null || !orderRepository.existsByOrderIdAndUserId(orderId, user.id())) {
-            log.warn("주문 조회 권한 없음");
-            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
-        }
-        log.info("주문 조회 권한 확인 성공");
-        List<OrderItem> orderItems =  orderItemRepository.findByOrderId(orderId);
-        List<OrderItemResponseDTO.OrderItemListResponseDTO> orderItemDTOS =
+    private static final LocalDateTime FIRST_CURSOR = LocalDateTime.now().plusDays(1);
+
+    public OrderResponseDTO.OrderDetailResponseDTO getOrderById(UUID orderId, CurrentUser user) {
+        validateUser(user);
+        validateOrderId(orderId);
+        validateOrderOwnership(orderId, user.id());
+
+        Order order = findOrderById(orderId);
+        List<OrderItem> orderItems = orderItemRepository.findByOrderId(orderId);
+        List<OrderItemResponseDTO.OrderItemListResponseDTO> orderItemDtos =
                 orderItems.stream().map(OrderItemConverter::toOrderItemClassListDTO).toList();
         
-        // store 정보 가져오기
-        StoreResponseDTO store = storeClient.storeById(order.getStore());
+        StoreResponseDTO store = fetchStoreInfo(order.getStore());
         
-        log.info("주문 조회 완료");
-        return OrderConverter.toOrderDetailResponseDTO(order, orderItemDTOS, store.getName());
+        log.info("주문 조회 완료 (orderId={})", orderId);
+        return OrderConverter.toOrderDetailResponseDTO(order, orderItemDtos, store.getName());
     }
 
     public OrderItemResponseDTO.OrderItemListResponseDTO getOrderItemById(UUID orderItemId, CurrentUser user){
@@ -81,10 +80,10 @@ public class OrderQueryService {
         }
         log.info("사용자 주문 목록 조회 권한 확인 성공");
         if(cursor == null) {
-            cursor = first_cursor;
+            cursor = FIRST_CURSOR;
         }
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Order> orders = orderRepository.findAllByUserId(user.id(),cursor,pageable);
+        Slice<Order> orders = orderRepository.findAllByUserId(user.id(), cursor, pageable);
         if(orders.isEmpty()) {
             log.warn("존재하지 않는 주문");
             throw new OrderException(OrderErrorCode.NOT_FOUND);
@@ -109,10 +108,10 @@ public class OrderQueryService {
             throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
         }
         if(cursor == null) {
-            cursor = first_cursor;
+            cursor = FIRST_CURSOR;
         }
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Order> orders = orderRepository.findAllByStoreId(storeId,cursor,pageable);
+        Slice<Order> orders = orderRepository.findAllByStoreId(storeId, cursor, pageable);
         if(orders.isEmpty()) {
             throw new OrderException(OrderErrorCode.NOT_FOUND);
         }
@@ -127,6 +126,44 @@ public class OrderQueryService {
             next_cursor = orderList.getLast().getCreatedAt();
         }
         log.info("가게 주문 목록 조회 완료");
-        return OrderConverter.toOrderStoreListResponseDTO(orderStoreResponseDTOS,orders.hasNext(),next_cursor);
+        return OrderConverter.toOrderStoreListResponseDTO(orderStoreResponseDTOS, orders.hasNext(), next_cursor);
+    }
+
+    private void validateUser(CurrentUser user) {
+        if (user == null || user.id() == null) {
+            log.warn("유효하지 않은 사용자");
+            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private void validateOrderId(UUID orderId) {
+        if (orderId == null) {
+            log.warn("Order ID가 null입니다");
+            throw new OrderException(OrderErrorCode.NOT_FOUND);
+        }
+    }
+
+    private void validateOrderOwnership(UUID orderId, UUID userId) {
+        if (!orderRepository.existsByOrderIdAndUserId(orderId, userId)) {
+            log.warn("주문 조회 권한 없음 (orderId={}, userId={})", orderId, userId);
+            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private Order findOrderById(UUID orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> {
+                    log.warn("존재하지 않는 주문: {}", orderId);
+                    return new OrderException(OrderErrorCode.NOT_FOUND);
+                });
+    }
+
+    private StoreResponseDTO fetchStoreInfo(UUID storeId) {
+        try {
+            return storeClient.storeById(storeId);
+        } catch (Exception e) {
+            log.error("스토어 정보 조회 실패 (storeId={})", storeId, e);
+            throw new OrderException(OrderErrorCode.NOT_FOUND);
+        }
     }
 }


### PR DESCRIPTION
## 🔘Part

- [x] option 다중 선택
- [x] 같은 menu, menuoption 인 경우 quantity +1
- [x] order option 연동

  <br/>
## ➕ 이슈 링크

- #66 

<br/>

## 🔎 작업 내용

- cart에서 cartitem이 menuoption 하나만 선택가능한 부분 수정

- menu, menuoption이 같은 경우 확인하고 quantity+1 하도록 함 - price 연동 추가

- 코드 리팩토링(중복 코드 제거, 캐싱 추가, dto validation 적용, 외부 api 반복 요청 제거)

- 불필요코드, import .*, 주석 제거

  <br/>

## 이미지 첨부


<br/>
